### PR TITLE
refactor: fields-in-formats

### DIFF
--- a/bibtex-actions.el
+++ b/bibtex-actions.el
@@ -322,33 +322,6 @@ personal names of the form 'family, given'."
          (car (split-string name ", "))))
      (split-string names " and ") ", ")))
 
-(defvar bibtex-actions-field-regex "${\\([^}]+\\)}"
-  "Regex for fields in templates.")
-
-(defun bibtex-actions--fields-for-format-alt (template)
-  "Return list of fields for TEMPLATE."
-  ;; An adaption of 's-match-strings-all'.
-  (declare (side-effect-free t))
-  (save-match-data
-    (let ((all-strings ())
-          (i 0))
-      (while (and (< i (length template))
-                  (string-match bibtex-actions-field-regex template i))
-        (setq i (1+ (match-beginning 0)))
-        (let (strings
-              (num-matches (/ (length (match-data)) 2))
-              (match 0))
-          (while (/= match num-matches)
-            (push (match-string match template) strings)
-            (setq match (1+ match)))
-          (push (nreverse strings) all-strings)))
-      ;; I'd rather construct the simple list to begin with, but not sure
-      ;; how ATM.
-      (seq-mapcat
-       (lambda (field)
-         (split-string (car (split-string field ":")) " "))
-       (seq-mapcat #'cdr (nreverse all-strings))))))
-
 (defun bibtex-actions--fields-for-format (template)
   "Return list of fields for TEMPLATE."
   ;; REVIEW I don't really like this code, but it works correctly.


### PR DESCRIPTION
Split out the local function, and use `s-match-strings-all` instead of `s-format`.

This now reads the note template, and ignores non-field content.

Could use further refactoring in the future.

cc @aikrahguzar let me know if any feedback. This should be more correct, but could be more elegant maybe. I'd for example prefer not to use s at all, but don't know of a better solution.

EDIT: the second commit adds an "alt" function that removes use of that s function by instead adapting it. I did not merge it, but it's here for the record.

https://github.com/bdarcus/bibtex-actions/pull/336/commits/30ed7f61d067fc52aa721b56db11282a1a450829