### PR TITLE
remove interactive def for select-style

### DIFF
--- a/oc-bibtex-actions.el
+++ b/oc-bibtex-actions.el
@@ -143,7 +143,6 @@ With PROC list, limit to specific processor(s)."
 ;;;###autoload
 (defun oc-bibtex-actions-select-style ()
   "Complete a citation style for org-cite with preview."
-  (interactive)
   (let* ((oc-styles
           ;; Sort the list upfront, but let completion UI handle beyond that.
           (sort (oc-bibtex-actions--style-candidates) 'string-lessp))


### PR DESCRIPTION
oc-bibtex-actions-select-styles does need to be interactive, as it's
 just called by org-cite-insert in the end.