### PR TITLE
feat: Use skeleton.el for formatting new notes

### DIFF
--- a/citar-file.el
+++ b/citar-file.el
@@ -184,7 +184,7 @@ Example: ':/path/to/test.pdf:PDF'."
                   nil 0 nil
                   file)))
 
-(defun citar-file--get-note-filename (key dirs extensions)
+(defun citar-file--get-note-filenames (key dirs extensions)
   "Return existing or new filename for KEY in DIRS with extension in EXTENSIONS.
 
 This is for use in a note function where notes are one-per-file,

--- a/citar-org.el
+++ b/citar-org.el
@@ -77,6 +77,19 @@ Each function takes one argument, a citation."
   :group 'citar-org
   :type '(repeat function))
 
+(defcustom citar-org-note-setup-id 'org-roam-only
+  "Whether `citar-org-note-setup` adds an Org ID."
+  :group 'citar-org
+  :type '(choice (const :tag "Always" t)
+                 (const :tag "Only in Org-roam buffers" org-roam-only)
+                 (const :tag "Never" nil)))
+
+(defcustom citar-org-note-setup-roam-ref t
+  "Whether `citar-org-note-setup` adds an Org-roam reference."
+  :group 'citar-org
+  :type '(choice (const :tag "In Org-roam buffers" t)
+                 (const :tag "Never" nil)))
+
 ;;; Keymaps
 
 (defvar citar-org-citation-map
@@ -253,6 +266,21 @@ of a new ID."
         (org-id-get-create force)
       (goto-char point)
       (set-marker point nil))))
+
+;;;###autoload
+(defun citar-org-note-setup (key)
+  "Add Org Id and/or Org-roam reference to element at point.
+See the customization options `citar-org-note-setup-id` and
+`citar-org-note-setup-roam-ref`."
+  (when (derived-mode-p 'org-mode)
+    (let ((roam (and (fboundp 'org-roam-buffer-p) (org-roam-buffer-p))))
+      (when (and citar-org-note-setup-id
+                 (or roam (not (eq 'org-roam-only citar-org-note-setup-id))))
+        (ignore-errors (citar-org-id-get-create)))
+      (when (and roam citar-org-note-setup-roam-ref)
+        (ignore-errors (org-roam-ref-add (concat "@" key))))))
+  ;; Return nil so nothing is inserted if used in skeleton
+  nil)
 
 ;;; Embark target finder
 

--- a/citar.el
+++ b/citar.el
@@ -107,16 +107,11 @@ for inserting formatted references."
 
 (defcustom citar-note-skeleton
   '(nil
-    \n                                  ; new line if not at beginning of line
-    '(and (derived-mode-p 'org-mode)
-          (fboundp 'org-roam-buffer-p)
-          (org-roam-buffer-p)
-          (ignore-errors (citar-org-id-get-create))
-          (ignore-errors (org-roam-ref-add (concat "@" &=key=))))
-    (when (derived-mode-p 'org-mode) "#+TITLE: ") | "# "
+    (when (derived-mode-p 'org-mode) (citar-org-note-setup))
+    (if (derived-mode-p 'org-mode) "#+TITLE: " "# ")
     "Notes on "
-    (when &title (format "\"%s\"" (citar-clean-string &title))) | (concat "@" &=key=)
-    \n \n _                             ; place point here
+    (if &title (format "\"%s\"" (citar-clean-string &title)) (concat "@" &=key=))
+    "\n\n" _
     (when (derived-mode-p 'org-mode) "\n\n#+print_bibliography:"))
   "Skeleton for newly created notes.
 See `skeleton-insert` for valid values.  Fields of the
@@ -124,7 +119,17 @@ bibliography entry are bound with names prefixed by '&'; for
 example the \"=key=\" field can be accessed using &=key=, the
 title using &title, etc.  The entry itself is bound to &=entry=."
   :group 'citar
-  :type '(repeat sexp))
+  :type '(list (choice :tag "Interactor"
+                       (const :tag "None" nil)
+                       (string :tag "Prompt")
+                       (sexp :tag "Expression"))
+               (repeat :inline t :tag "Elements"
+                       (choice :value "" :tag ""
+                               (const :tag "New line and indent" \n)
+                               (const :tag "Indent" >)
+                               (string :tag "Text")
+                               (const :tag "Cursor" _)
+                               (sexp :tag "Eval")))))
 
 (defcustom citar-insert-reference-function
   #'citar--insert-reference


### PR DESCRIPTION
Allows for new features, like running Elisp code during note setup, deciding where point should be placed, etc.

- [ ] Update README
- [ ] Decide on a reasonable default for `citar-note-skeleton`
- [ ] Should we split the note functions into a separate `citar-notes.el` file?
- [ ] Do we need more customization points?

Fixes #420.