### PR TITLE
feat: Add citar-pdf.el

### DIFF
--- a/citar-pdf.el
+++ b/citar-pdf.el
@@ -1,0 +1,47 @@
+;;; citar-pdf.el --- citar and pdf-tools inegration -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2021 Bruce D'Arcus
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Provides integration code for working with PDF files from within Citar.
+
+;;; Code:
+
+(require 'citar)
+(require 'pdf-occur)
+
+;;;###autoload
+(defun citar-pdf-search-contents (keys-entries &optional str)
+  "Search PDFs files using KEYS-ENTRIES.
+
+Optional search STR can be provided in non-interactive contexts."
+  (interactive (list (citar-select-refs)))
+  (let ((files (citar-file--files-for-multiple-entries
+                (citar--ensure-entries keys-entries)
+                citar-library-paths
+                '("pdf")))
+        (search-str (or str (read-string "Search string: "))))
+    (pdf-occur-search files search-str t)))
+
+(eval-after-load 'embark
+  (when (boundp 'embark-multitarget-actions)
+    (add-to-list 'embark-multitarget-actions #'citar-pdf-search-contents)))
+
+(provide 'citar-pdf)
+;;; citar-pdf.el ends here


### PR DESCRIPTION
Actually, this probably is premature.

I was just realizing one could adapt `consult-ripgrep` to use `ripgrep-all` instead, and the performance is _much_ better. Except, it doesn't appear you can open the file from the candidate.

![image](https://user-images.githubusercontent.com/1134/146383113-f51db364-d8b7-4f76-bac6-4134ae253669.png)

-----

This adds the `citar-pdf-search-contents` command from #477, in its own file, both to separately handle dependencies, but also with the idea to leave room for adding other functions here in time. 

An issue is that I'm not sure what ATM what might be reasonably added in the future. Maybe something related to org-noter? Might be this is premature without that settled?