### PR TITLE
Add start of eldev linting, etc.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,11 @@
+
+((emacs-lisp-mode
+  (fill-column . 110)
+  (indent-tabs-mode . nil)
+  (elisp-lint-ignored-validators . ("byte-compile" "package-lint"))
+  (elisp-lint-indent-specs . ((describe . 1)
+                              (it . 1)
+                              (thread-first . 0)
+                              (cl-flet . 1)
+                              (sentence-end-double-space . nil)
+                              (cl-flet* . 1)))))

--- a/Eldev
+++ b/Eldev
@@ -1,0 +1,22 @@
+; -*- mode: emacs-lisp; lexical-binding: t; no-byte-compile: t -*-
+;; this and related files adapted from org-roam
+;; explicitly set main file
+(setf eldev-project-main-file "citar.el")
+
+(eldev-use-package-archive 'gnu)
+(eldev-use-package-archive 'melpa-unstable)
+
+;; allow to load test helpers
+;(eldev-add-loading-roots 'test "test/utils")
+
+;; Tell checkdoc not to demand two spaces after a period.
+(setq sentence-end-double-space nil)
+
+(setf eldev-lint-default '(elisp))
+;(setf eldev-standard-excludes `(:or ,eldev-standard-excludes "org-roam-macs.el"))
+
+(with-eval-after-load 'elisp-lint
+  ;; We will byte-compile with Eldev.
+  (setf elisp-lint-ignored-validators '("package-lint" "fill-column")
+        enable-local-variables        :all))
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+
+.PHONY: clean
+clean:
+	eldev clean all
+
+.PHONY: lint
+lint:
+	eldev -C --unstable -T lint
+


### PR DESCRIPTION
Would something like this be useful, @roshanshariff, that in time we could hook up to the CI, including unit tests, etc?

Right now, all that works is `make lint`, where it will flag a ton of things, mostly code formatting/indenting.

I had an earlier github actions setup (code still here), but I found it too interventionist.

This would reject PRs (in the sense mark them needing fixes) with these warning though.

But my thought is in the interim, could add it and ask contributors to use it? I know it would be useful for me!