### PR TITLE
pre-1.0-cleanup branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,7 @@ clean:
 lint:
 	eldev -C --unstable -T lint
 
+.PHONY: test
+test:
+	eldev -C --unstable -T test
+

--- a/citar-cache.el
+++ b/citar-cache.el
@@ -1,22 +1,8 @@
 ;;; citar-cache.el --- Cache functions for citar -*- lexical-binding: t; -*-
 ;;
-;; Copyright (C) 2022 Bruce D'Arcus, Roshan Shariff
-;;
-;; This file is not part of GNU Emacs.
-;;
-;; This program is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
+;; SPDX-FileCopyrightText: 2022 Bruce D'Arcus, Roshan Shariff
+;; SPDX-License-Identifier: GPL-3.0-or-later
 
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
-;;
 ;;; Commentary:
 ;;
 ;;  Functions for caching bibliography files.

--- a/citar-capf.el
+++ b/citar-capf.el
@@ -1,10 +1,9 @@
 ;;; citar-capf.el --- citar completion-at-point -*- lexical-binding: t; -*-
 ;;
-;; Copyright (C) 2022 Bruce D'Arcus, Colin McLear
+;; SPDX-FileCopyrightText: 2022 Bruce D'Arcus, Colin McLear
+;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
 ;; This file is not part of GNU Emacs.
-;;
-;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
 ;;; Commentary:
 ;;

--- a/citar-citeproc.el
+++ b/citar-citeproc.el
@@ -1,19 +1,7 @@
 ;;; citar-citeproc.el --- Citeproc reference support for citar -*- lexical-binding: t; -*-
 ;;
-;; This file is not part of GNU Emacs.
-;;
-;; This program is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
-
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; SPDX-FileCopyrightText: 2021-2022 Bruce D'Arcus
+;; SPDX-License-Identifier: GPL-3.0-or-later
 
 ;;; Commentary:
 

--- a/citar-embark.el
+++ b/citar-embark.el
@@ -53,7 +53,8 @@
 (defvar citar-embark--multitarget-actions
   (list #'citar-open #'citar-open-files #'citar-attach-files #'citar-open-links
         #'citar-insert-bibtex #'citar-insert-citation #'citar-insert-reference
-        #'citar-copy-reference #'citar-insert-keys #'citar-run-default-action))
+        #'citar-copy-reference #'citar-insert-keys #'citar-run-default-action
+        #'citar-open-notes))
 
 (defvar citar-embark--target-injection-hooks
   (list (list #'citar-insert-edit #'embark--ignore-target)))

--- a/citar-embark.el
+++ b/citar-embark.el
@@ -1,12 +1,13 @@
 ;;; citar-embark.el --- Citar/Embark integration -*- lexical-binding: t; -*-
 ;;
-;; Copyright (C) 2022 Bruce D'Arcus
-;;
 ;; Author: Bruce D'Arcus <bdarcus@gmail.com>
 ;; Maintainer: Bruce D'Arcus <bdarcus@gmail.com>
 ;; Created: June 22, 2022
 ;; Modified: June 22, 2022
+;;
+;; SPDX-FileCopyrightText: 2021-2022 Bruce D'Arcus
 ;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Version: 1.0
 ;; Keywords: bib extensions
 ;; Homepage: https://github.com/emacs-citar/citar-embark

--- a/citar-file.el
+++ b/citar-file.el
@@ -1,21 +1,9 @@
 ;;; citar-file.el --- File functions for citar -*- lexical-binding: t; -*-
 ;;
-;; Copyright (C) 2021 Bruce D'Arcus
-;;
+;; SPDX-FileCopyrightText: 2021-2022 Bruce D'Arcus
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
 ;; This file is not part of GNU Emacs.
-;;
-;; This program is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
-
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;;
 ;;; Commentary:
 ;;

--- a/citar-file.el
+++ b/citar-file.el
@@ -332,7 +332,7 @@ need to scan the contents of DIRS in this case."
             (file-exists (file-exists-p file)))
       (find-file file)
     (if (and (null citar-notes-paths)
-             (equal (citar--get-notes-config :action)
+             (equal (citar--get-notes-config :open)
                     'citar-org-format-note-default))
         (error "You must set 'citar-notes-paths'")
       (funcall

--- a/citar-format.el
+++ b/citar-format.el
@@ -1,21 +1,7 @@
 ;;; citar-format.el --- Formatting functions for citar -*- lexical-binding: t; -*-
 ;;
-;; Copyright (C) 2022 Bruce D'Arcus, Roshan Shariff
-;;
-;; This file is not part of GNU Emacs.
-;;
-;; This program is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
-
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; SPDX-FileCopyrightText: 2021-2022 Bruce D'Arcus, Roshan Shariff
+;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
 ;;; Commentary:
 ;;

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -1,28 +1,14 @@
 ;;; citar-latex.el --- Latex adapter for citar -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021 Bruce D'Arcus
-
-;; This file is not part of GNU Emacs.
-
-;; This program is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
-
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; SPDX-FileCopyrightText: 2021-2022 Bruce D'Arcus
+;; SPDX-License-Identifier: GPL-3.0-or-later
 
 ;;; Commentary:
 
 ;; A small package that provides the functions required to use citar
 ;; with latex.
 
-;; Simply loading this file will enable manipulating the citations with
+;; Loading this file will enable manipulating the citations with
 ;; commands provided by citar.
 
 ;;; Code:

--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -1,29 +1,14 @@
 ;;; citar-markdown.el --- Markdown adapter for citar -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021 Bruce D'Arcus
-
-;; This file is not part of GNU Emacs.
-
-;; This program is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
-
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; SPDX-FileCopyrightText: 2021-2022 Bruce D'Arcus
+;; SPDX-License-Identifier: GPL-3.0-or-later
 
 ;;; Commentary:
 
-;; A small package that provides the functions required to use citar
-;; with markdown.
+;; A small package that provides functions required to use citar with markdown.
 
-;; Simply loading this file will enable manipulating the citations with
-;; commands provided by citar.
+;; Loading this file will enable manipulating the citations with commands
+;; provided by citar.
 
 ;;; Code:
 

--- a/citar-org.el
+++ b/citar-org.el
@@ -1,22 +1,10 @@
 ;;; citar-org.el --- Org-cite support for citar -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021 Bruce D'Arcus
+;; SPDX-FileCopyrightText: 2021-2022 Bruce D'Arcus
+;; SPDX-License-Identifier: GPL-3.0-or-later
 
 ;; This file is not part of GNU Emacs.
-
-;; This program is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
-
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+;;
 ;;; Commentary:
 
 ;;  This is a small package that integrates citar and org-cite.  It

--- a/citar.el
+++ b/citar.el
@@ -7,33 +7,17 @@
 ;; Created: February 27, 2021
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Version: 0.9.7
-;; Homepage: https://github.com/bdarcus/citar
+;; Homepage: https://github.com/emacs-citar/citar
 ;; Package-Requires: ((emacs "27.1") (parsebib "3.0") (org "9.5") (citeproc "0.9"))
 
 ;; This file is not part of GNU Emacs.
-
-;; This program is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
-
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+;;
 ;;; Commentary:
 
 ;;  A completing-read front-end to browse, filter and act on BibTeX, BibLaTeX,
 ;;  and CSL JSON bibliographic data, including LaTeX, markdown, and org-cite
 ;;  citation editing support.
 ;;
-;;  With embark, it also provides access to contextual actions, both in the
-;;  minibuffer, and in the buffer at-point.
-
 ;;; Code:
 
 (eval-when-compile

--- a/citar.el
+++ b/citar.el
@@ -656,16 +656,15 @@ user declined to choose."
       (when-let ((selected
                   (if (and (not always-prompt) (null (cdr cands)))
                       (car cands)
-                    (let* ((selected (completing-read
-                                      "Select resource: "
-                                      (lambda (string predicate action)
-                                        (if (eq action 'metadata)
-                                            `(metadata
-                                              (group-function . ,#'citar--select-group-related-resources)
-                                              (annotation-function . ,#'citar--annotate-note)
-                                              ,@(when category `((category . ,category))))
-                                          (complete-with-action action cands string predicate)))
-                                      nil t)))
+                    (let* ((metadata `(metadata
+                                       (group-function . ,#'citar--select-group-related-resources)
+                                       (annotation-function . ,#'citar--annotate-note)
+                                       ,@(when category `((category . ,category)))))
+                           (table (lambda (string predicate action)
+                                    (if (eq action 'metadata)
+                                        metadata
+                                      (complete-with-action action cands string predicate))))
+                           (selected (completing-read "Select resource: " table nil t)))
                       (car (member selected cands))))))
         (cons (get-text-property 0 'citar--resource selected) (substring-no-properties selected))))))
 

--- a/citar.el
+++ b/citar.el
@@ -611,7 +611,7 @@ CANDIDATES."
          (links (if (listp links) links (citar-get-links key-or-keys)))
          (notes
           (when-let* ((notes)
-                      (keys (if (listp key-or-keys) key-or-keys (list key-or-keys)))
+                      (keys (citar--with-crossref-keys key-or-keys))
                       (getitems (citar--get-notes-config :items))
                       (items (funcall getitems keys)))
             (mapcar (lambda (item) (propertize item 'citar--note t)) items)))

--- a/citar.el
+++ b/citar.el
@@ -930,7 +930,7 @@ have similar usage."
 
 
 (defun citar--has-resources (predicates)
-  "Combine PREDICATES into a single function that checks cross-refs.
+  "Combine PREDICATES into a single resource predicate.
 
 PREDICATES should be a list of functions that take a bibliography
 KEY and return non-nil if the item has a resource. It may also be
@@ -1103,17 +1103,16 @@ cross-referenced keys, if any."
                                                         (open (citar--get-notes-config :open)))
                                                (list (cons notecat open)))
                                            . ,embark-default-action-overrides)))
-      (if-let ((resource (citar--select-resource keys
-                                                 :files t :links t :notes t
-                                                 :always-prompt citar-open-prompt)))
-          ;; TODO Does this work for non-file notes?
-          (citar--open-multi resource)
-        (error "No associated resources: %s" keys))))
+    (if-let ((resource (citar--select-resource keys :files t :links t :notes t
+                                               :always-prompt citar-open-prompt)))
+        ;; TODO Does this work for non-file notes?
+        (citar--open-multi resource)
+      (error "No associated resources: %s" keys))))
 
 (defun citar--open-multi (selection)
   "Act appropriately on SELECTION when type is `multi-category'.
 For use with `embark-act-all'."
-;; TODO Fix this so that `citar-open' can open non-file notes
+  ;; TODO Fix this so that `citar-open' can open non-file notes
   (cond ((string-match "http" selection 0)
          (browse-url selection))
         ((member t (mapcar (lambda (x)

--- a/citar.el
+++ b/citar.el
@@ -1102,7 +1102,7 @@ cross-referenced keys, if any."
                                            ,@(when-let ((notecat (citar--get-notes-config :category))
                                                         (open (citar--get-notes-config :open)))
                                                (list (cons notecat open)))
-                                           . ,embark-default-action-overrides)))
+                                           . ,(bound-and-true-p embark-default-action-overrides))))
     (if-let ((resource (citar--select-resource keys :files t :links t :notes t
                                                :always-prompt citar-open-prompt)))
         ;; TODO Does this work for non-file notes?
@@ -1139,8 +1139,9 @@ For use with `embark-act-all'."
   "Run ACTION on file associated with KEY-OR-KEYS.
 If KEY-OR-KEYS have multiple files, use `completing-read' to
 select a single file."
-  (let* ((citar--entries (citar-get-entries))
-         (embark-default-action-overrides `((file . ,action) . ,embark-default-action-overrides)))
+  (let ((citar--entries (citar-get-entries))
+        (embark-default-action-overrides `((file . ,action)
+                                           . ,(bound-and-true-p embark-default-action-overrides))))
     (if-let ((file (citar--select-resource key-or-keys :files t)))
         (funcall action file)
       (ignore

--- a/citar.el
+++ b/citar.el
@@ -256,7 +256,7 @@ If nil, single resources will open without prompting."
                 ,(list :name "Notes"
                        :category 'file
                        :hasnote #'citar-file-has-notes
-                       :action #'citar-file--open-note
+                       :open #'citar-file--open-note
                        :create #'citar-org-format-note-default ; TODO remove?
                        :items #'citar-file--get-note-files)))
   "The alist of notes backends available for configuration.
@@ -270,7 +270,7 @@ plist has the following properties:
 
   :hasnote function to test for keys with notes
 
-  :action function to open a given note candidate
+  :open function to open a given note candidate
 
   :items function to return candidate strings for keys
 
@@ -1154,7 +1154,7 @@ For use with `embark-act-all'."
   (dolist (key keys)
     (let ((entry (citar-get-entry key)))
       (funcall
-       (citar--get-notes-config :action) key entry))))
+       (citar--get-notes-config :open) key entry))))
 
 ;;;###autoload
 (defun citar-open-links (keys)
@@ -1349,7 +1349,7 @@ VARIABLES should be the names of Citar customization variables."
            (error "`%s' should be a list of strings: %S" variable `',value)))
         ((or 'citar-has-files-functions 'citar-get-files-functions
                                         ;  (citar--get-notes-config :hasnote)
-                                        ;  (citar--get-notes-config :action)
+                                        ;  (citar--get-notes-config :open)
              'citar-file-parser-functions)
          (unless (and (listp value) (seq-every-p #'functionp value))
            (error "`%s' should be a list of functions: %S" variable `',value)))

--- a/test/citar-file-test.el
+++ b/test/citar-file-test.el
@@ -46,11 +46,10 @@
 
 (ert-deftest citar-file-test--parse-file-field ()
 
-  (let* ((fieldname "file")
+  (let* ((citar-file-variable "file")
          (citekey "foo")
-         (entry '((file . "foo.pdf")))
+         (fieldvalue "foo.pdf")
          (dirs '("/home/user/library/"))
-         (citar-file-variable fieldname)
          (citar-file-parser-functions (list #'citar-file--parser-default))
          lastmessage)
 
@@ -66,20 +65,20 @@
                  (and (equal "pdf" (file-name-extension filename))
                       (member (file-name-directory filename) dirs)))))
 
-      (should-not (citar-file--parse-file-field '((file . " ")) dirs citekey))
+      (should-not (citar-file--parse-file-field " " dirs citekey))
       (should (string=
                (current-message)
-               (format-message "Empty `%s' field: %s" fieldname citekey)))
+               (format-message "Empty `%s' field: %s" citar-file-variable citekey)))
 
       (let ((citar-file-parser-functions nil))
-        (should-not (citar-file--parse-file-field entry dirs citekey))
+        (should-not (citar-file--parse-file-field fieldvalue dirs citekey))
         (should (string=
                  (current-message)
                  (format-message
                   "Could not parse `%s' field of `%s'; check `citar-file-parser-functions': %s"
-                  fieldname citekey (alist-get 'file entry)))))
+                  citar-file-variable citekey fieldvalue))))
 
-      (should-not (citar-file--parse-file-field '((file . "foo.html")) dirs citekey))
+      (should-not (citar-file--parse-file-field "foo.html" dirs citekey))
       (should (string=
                (current-message)
                (format-message
@@ -88,7 +87,7 @@
                 citekey '("foo.html"))))
 
       (let ((citar-library-file-extensions '("html")))
-        (should-not (citar-file--parse-file-field entry dirs citekey))
+        (should-not (citar-file--parse-file-field fieldvalue dirs citekey))
         (should (string=
                  (current-message)
                  (format-message
@@ -96,11 +95,11 @@
                   citekey '("/home/user/library/foo.pdf")))))
 
       (let ((citar-library-file-extensions nil))
-        (should (equal (citar-file--parse-file-field entry dirs citekey)
+        (should (equal (citar-file--parse-file-field fieldvalue dirs citekey)
                         '("/home/user/library/foo.pdf"))))
 
       (let ((citar-library-file-extensions '("pdf" "html")))
-        (should (equal (citar-file--parse-file-field entry dirs citekey)
+        (should (equal (citar-file--parse-file-field fieldvalue dirs citekey)
                         '("/home/user/library/foo.pdf")))))))
 
 (provide 'citar-file-test)

--- a/test/citar-test.el
+++ b/test/citar-test.el
@@ -1,0 +1,16 @@
+;;; citar-file-test.el --- Tests for citar.el  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'ert)
+(require 'citar)
+(require 'map)
+
+(ert-deftest citar-test--check-notes-sources ()
+  ;; This should run without signalling an error
+  (should-not (ignore (map-do #'citar--check-notes-source citar-notes-sources))))
+
+(provide 'citar-test)
+;;; citar-test.el ends here


### PR DESCRIPTION
I was realizing I was making too many small commits, so setup this branch to collect various commits to get this repo ready for tagging 1.0 in the next week or so.

The first commit emerged out of a suggestion from the MELPA review for citar-embark, and that is to use these for the file headers:

https://spdx.dev/ids/

So I've done that, and also removed the human-readable license text. I hope that's OK; I guess it should be if MELPA folks recommended it.

@localauthor and @aikrahguzar - not sure if you wanted your names on the copyright for some of these files?

-------------

### Questions/Issues

1. I'm not sure on this, but on the note API, I'm leaning towards only defining the `:action` function (or we could all it `:open`?), and leaving out the `:create` one. My reasoning is that creating new notes is pretty closely-tied to opening them, and so better to just have the API reflect that. Yes, if someone wants something like the default source for markdown, it will mean having to copy and adjust the default function(s). But that seems a small price to pay. And at least with `citar-org-roam`, there's no value in a separate configurable function for new notes.