### PR TITLE
add citar-open-gscholar command

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -1189,6 +1189,17 @@ For use with `embark-act-all'."
     (bibtex-search-entry key t nil t)))
 
 ;;;###autoload
+(defun citar-open-gscholar (key-entry)
+  "Open Google Scholar query result associated with the KEY-ENTRY.
+With prefix, rebuild the cache before offering candidates."
+  (interactive (list (citar-select-ref
+                      :rebuild-cache current-prefix-arg)))
+  (let* ((entry (cdr key-entry))
+         (title (alist-get "title" entry nil nil #'equal))
+         (url (url-encode-url (format "https://scholar.google.com/scholar?q=%s" title) )))
+    (browse-url-xdg-open url)))
+
+;;;###autoload
 (defun citar-insert-bibtex (keys)
   "Insert bibliographic entry associated with the KEYS."
   (interactive (list (citar-select-refs)))


### PR DESCRIPTION
During my research workflow, I often find myself querying Google Scholar for academic papers' info.
This PR aims to make it more convenient to do so in `citar`.
Any comment is welcome!