### PR TITLE
Use citar--select-resource for citar-open-notes

### DIFF
--- a/citar-file.el
+++ b/citar-file.el
@@ -325,12 +325,12 @@ extensions in `citar-file-note-extensions'."
 (defun citar-file--create-note (key)
   "Create a note file from KEY and ENTRY."
   (let ((entry (citar-get-entry key)))
-  (if-let ((filename (citar-file--get-note-filename key)))
-      (prog1 (find-file filename)
-        (unless (file-exists-p filename)
-          (citar--check-configuration 'citar-note-format-function)
-          (funcall citar-note-format-function key entry)))
-    (user-error "Make sure `citar-notes-paths' and `citar-file-note-extensions' are non-nil"))))
+    (if-let ((filename (citar-file--get-note-filename key)))
+        (prog1 (find-file filename)
+          (unless (file-exists-p filename)
+            (citar--check-configuration 'citar-note-format-function)
+            (funcall citar-note-format-function key entry)))
+      (user-error "Make sure `citar-notes-paths' and `citar-file-note-extensions' are non-nil"))))
 
 (defun citar-file--get-notes (keys)
   "Return list of notes associated with KEYS."

--- a/citar-file.el
+++ b/citar-file.el
@@ -322,14 +322,15 @@ extensions in `citar-file-note-extensions'."
   (let ((files (citar-file--note-directory-files)))
     (lambda (key) (gethash key files))))
 
-(defun citar-file--create-note (key entry)
+(defun citar-file--create-note (key)
   "Create a note file from KEY and ENTRY."
+  (let ((entry (citar-get-entry key)))
   (if-let ((filename (citar-file--get-note-filename key)))
       (prog1 (find-file filename)
         (unless (file-exists-p filename)
           (citar--check-configuration 'citar-note-format-function)
           (funcall citar-note-format-function key entry)))
-    (user-error "Make sure `citar-notes-paths' and `citar-file-note-extensions' are non-nil")))
+    (user-error "Make sure `citar-notes-paths' and `citar-file-note-extensions' are non-nil"))))
 
 (defun citar-file--get-notes (keys)
   "Return list of notes associated with KEYS."

--- a/citar.el
+++ b/citar.el
@@ -622,7 +622,7 @@ CANDIDATES."
            (sources (nconc (when files (list (cons 'file (withtype 'file files))))
                            (when links (list (cons 'url (withtype 'url links))))
                            (when notes (list (cons notecat (withtype 'note notes))))
-                           (when notes (list (cons 'key (withtype 'key key-or-keys)))))))
+                           (list (cons 'key (withtype 'key key-or-keys))))))
       (if (null (cdr sources))        ; if sources is nil or singleton list,
           (car sources)               ; return either nil or the only source.
         (cons 'multi-category         ; otherwise, combine all sources

--- a/citar.el
+++ b/citar.el
@@ -861,7 +861,7 @@ If KEY-OR-KEYS is omitted, return all notes."
   "Create a note for KEY and ENTRY.
 If ENTRY is nil, use `citar-get-entry' with KEY."
   (interactive (list (citar-select-ref)))
-  (funcall (citar--get-notes-config :create) key (or entry (citar-get-entry key))))
+  (funcall (citar--get-notes-config :create) key))
 
 (defun citar-get-files (key-or-keys)
   "Return list of files associated with KEY-OR-KEYS.
@@ -1183,7 +1183,7 @@ select a single file."
          (key (cdr resource)))
     (if (eq 'note (car resource))
         (funcall (citar--get-notes-config :open) key)
-      (funcall (citar--get-notes-config :create) key (citar-get-entry key)))))
+      (funcall (citar--get-notes-config :create) key))))
 
 ;;;###autoload
 (defun citar-open-links (key-or-keys)

--- a/citar.el
+++ b/citar.el
@@ -679,9 +679,12 @@ user declined to choose."
     ('note (if transform
                (funcall (or (citar--get-notes-config :transform) #'identity) resource)
              "Open Notes:"))
+    ('key (if transform
+              resource
+            "Create Notes:"))
     (_ (if transform
            resource
-         "Create Notes:"))))
+         nil))))
 
 (defun citar--format-candidates ()
   "Format completion candidates for bibliography entries.

--- a/citar.el
+++ b/citar.el
@@ -1135,7 +1135,8 @@ property specifying TYPE."
             (open (pcase type
                     ('file #'citar-file-open)
                     ('url #'browse-url)
-                    ('note (citar--get-notes-config :open)))))
+                    ('note (citar--get-notes-config :open))
+                    ('key (citar--get-notes-config :create)))))
       (funcall open (substring-no-properties resource))
     (error "Could not open resource of type `%s': %S" type resource)))
 

--- a/citar.el
+++ b/citar.el
@@ -1178,11 +1178,11 @@ select a single file."
 (defun citar-open-notes (keys)
   "Open notes associated with the KEYS."
   (interactive (list (citar-select-refs)))
-  (if-let ((notes (citar-get-notes keys)))
-      (progn (mapc (citar--get-notes-config :open) notes)
-             (let ((count (length notes)))
-               (when (> count 1)
-                 (message "Opened %d notes" count))))
+  (if (citar-get-notes keys)
+      (funcall (citar--get-notes-config :open)
+               (cdr (citar--select-resource keys
+                                            :notes t
+                                            :always-prompt citar-open-prompt)))
     (when keys
       (if (null (cdr keys))
           (citar-create-note (car keys))

--- a/citar.el
+++ b/citar.el
@@ -1186,7 +1186,10 @@ select a single file."
     (when keys
       (if (null (cdr keys))
           (citar-create-note (car keys))
-        (message "No notes found. Select one key to create note: %s" keys)))))
+        (citar-create-note
+         (completing-read
+          "No notes found. Select one key to create note: "
+          keys))))))
 
 ;;;###autoload
 (defun citar-open-links (key-or-keys)


### PR DESCRIPTION
Is there a reason why `citar-open-notes` doesn't use `citar--select-resource`?

I've got a few cases of multiple notes for a key and I wanted a chance to select one, rather than have all notes opened at once. Not sure this is the right answer, but maybe in the right direction?

Also, the message in the last line of `citar-open-notes`  tells the user to "Select one key to create note". Was that meant to be interactive? I've thrown in a possible way of doing that here.

Thoughts?