### PR TITLE
Improve note creation functionality (and tweak API)

### DIFF
--- a/citar-cache.el
+++ b/citar-cache.el
@@ -16,8 +16,9 @@
 (require 'seq)
 (require 'map)
 
-(declare-function citar--get-template "citar")
-(declare-function citar--fields-to-parse "citar")
+(declare-function citar--get-template "citar" (template-name))
+(declare-function citar--fields-to-parse "citar" ())
+(declare-function citar--prepend-candidate-citekey "citar" (citekey candidate))
 
 (defvar citar-ellipsis)
 
@@ -254,16 +255,8 @@ PROPS."
      (lambda (citekey entry)
        (let* ((preformat (citar-format--preformat fieldspecs entry
                                                   t citar-ellipsis))
-              ;; CSL-JSON lets citekey be an arbitrary string. Quote it if...
-              (keyquoted (if (or (string-empty-p citekey) ; ... it's empty,
-                                 (= ?\" (aref citekey 0)) ; ... starts with ",
-                                 (seq-contains-p citekey ?\s #'=))   ; ... or has a space
-                             (prin1-to-string citekey)
-                           citekey))
-              (prefix (propertize (concat keyquoted (when (cdr preformat) " "))
-                                  'invisible t)))
-         (setcdr preformat (cons (concat prefix (cadr preformat))
-                                 (cddr preformat)))
+              (withkey (citar--prepend-candidate-citekey citekey (cadr preformat))))
+         (setcdr preformat (cons withkey (cddr preformat)))
          (puthash citekey preformat preformatted)))
      entries)))
 

--- a/citar-embark.el
+++ b/citar-embark.el
@@ -73,7 +73,8 @@
 
 (defun citar-embark--candidate-transformer (_type target)
   "Look up key for a citar-reference TYPE and TARGET."
-  (cons 'citar-reference (citar--extract-candidate-citekey target)))
+  (or (get-text-property 0 'multi-category target)
+      (cons 'citar-reference (citar--extract-candidate-citekey target))))
 
 (defun citar-embark--selected ()
   "Return selected candidates from `citar--select-multiple' for embark."

--- a/citar-format.el
+++ b/citar-format.el
@@ -18,10 +18,12 @@
 ;;; Formatting bibliography entries
 
 
-(cl-defun citar-format--entry (format-string entry &optional width
-                                             &key hide-elided ellipsis)
-  "Format ENTRY according to FORMAT-STRING."
-  (let* ((fieldspecs (citar-format--parse format-string))
+(cl-defun citar-format--entry (format entry &optional width
+                                      &key hide-elided ellipsis)
+  "Format ENTRY according to FORMAT.
+FORMAT may be either a format string or a parsed format string as
+returned by `citar-format--parse'."
+  (let* ((fieldspecs (if (stringp format) (citar-format--parse format) format))
          (preform (citar-format--preformat fieldspecs entry
                                            hide-elided ellipsis)))
     (if width


### PR DESCRIPTION
This PR continues #658.

### `citar-open` and `citar-open-notes` can now create notes

Both these functions now offer to create notes for the chosen keys. The customization variable `citar-open-always-create-note` controls whether the "create" option is offered only for keys that don't already have notes. Regardless of this variable's value, the `citar-create-note` command can always be used to create multiple notes for any key, if supported by the `citar-note-source`.

This new feature is implemented as an extra option to `citar--select-resource`, which has now learned about the `create-note` pseudo-resource type. The `citar-open-notes` and `citar--open-resource` functions also learned to create new notes.

### Other Changes

There is a new command called `citar-open-note`, which prompts to select a note from all the available notes and opens it. It can also be called non-interactively with a note returned by `citar-get-notes`, which is its primary purpose.

The customization variable `citar-open-prompt` can now be set to a list of commands that will always prompt before selecting resources. The default is to always prompt for `citar-open`, `citar-attach-files`, and `citar-open-note`. This should fix the UX issue identified in #656.

The new customization variable `citar-open-resources` controls which resources are offered by `citar-open`. By default it is set to `'(:files :links :notes :create-notes)`, but any of those can be removed if desired.

### API changes

The first commit in this PR modifies the API to make the above changes easier.

The `citar-get-files`, `citar-get-links`, and `citar-get-notes` functions now return hash tables mapping each key to a list of associated resources. They used to just return lists of resources for all the given keys, but that interface doesn't allow callers to determine which key corresponds to each resource.

The `:items` function in the notes source API has also been modified, and must now return a hash table instead of a list of notes.

emacs-citar/citar-org-roam#6 updates the `citar-org-roam` note source to conform to this change.

### Remaining work

We don't yet have a "multi-select" interface to `citar-open` and friends. `embark-act-all` can be used to act on all the presented candidates, but this doesn't allow you to select some smaller subset.