### PR TITLE
Make `citar-file-open` use customizable functions to open files

### DIFF
--- a/README.org
+++ b/README.org
@@ -257,7 +257,8 @@ If you have a mix of entries created with Zotero and Calibre, you can set it lik
 
 The ~citar-file-extensions~ variable governs which file extensions the open commands will recognize.
 
-The =citar-open-library-files= command includes an optional file browser, which can be set with the ~citar-file-open-prompt~ boolean variable.
+To change how files with given extensions are opened, customize the ~citar-file-open-functions~ variable defined in =citar-file.el=.
+
 When used with embark and consult, you will have a range of alternate actions available for the candidates.
 
 #+CAPTION: File candidates with embark options

--- a/citar-cache.el
+++ b/citar-cache.el
@@ -78,7 +78,7 @@ Remove any existing associations between BUFFER and cached files
 not included in FILENAMES. Release cached files that are no
 longer needed by any other buffer.
 
-Return a list of `citar--bibliography' objects, one for each
+Return a list of `citar-cache--bibliography' objects, one for each
 element of FILENAMES."
   (citar-cache--release-bibliographies filenames buffer)
   (let ((buffer (citar-cache--canonicalize-buffer buffer)))

--- a/citar-file.el
+++ b/citar-file.el
@@ -82,7 +82,7 @@ separator that does not otherwise occur in citation keys."
                  (const :tag "Find files with space after key" "[[:space:]]")
                  (regexp :tag "Filename separator")))
 
-(defcustom citar-file-open-external-extension '("html")
+(defcustom citar-file-open-external-extensions '("html")
   "List of file extensions to be opened with external application.
 
 These are the extensions the `citar-file-open-external'

--- a/citar-file.el
+++ b/citar-file.el
@@ -82,6 +82,14 @@ separator that does not otherwise occur in citation keys."
                  (const :tag "Find files with space after key" "[[:space:]]")
                  (regexp :tag "Filename separator")))
 
+(defcustom citar-file-open-external-extension '("html")
+  "List of file extensions to be opened with external application.
+
+These are the extensions the `citar-file-open-external'
+will open, via `citar-file-open'."
+  :group 'citar
+  :type '(repeat string))
+
 (defvar citar-notes-paths)
 (defvar citar-library-paths)
 (defvar citar-library-file-extensions)
@@ -288,7 +296,9 @@ need to scan the contents of DIRS in this case."
 
 (defun citar-file-open (file)
   "Open FILE."
-  (if (equal (file-name-extension file) "html")
+  (if (cl-member (downcase (file-name-extension file))
+                 citar-file-open-external-extension
+                 :test #'equal)
       (citar-file-open-external (expand-file-name file))
     (funcall citar-file-open-function (expand-file-name file))))
 

--- a/citar-file.el
+++ b/citar-file.el
@@ -296,9 +296,7 @@ need to scan the contents of DIRS in this case."
 
 (defun citar-file-open (file)
   "Open FILE."
-  (if (cl-member (downcase (file-name-extension file))
-                 citar-file-open-external-extension
-                 :test #'equal)
+  (if (member-ignore-case (file-name-extension file) citar-file-open-external-extensions)
       (citar-file-open-external (expand-file-name file))
     (funcall citar-file-open-function (expand-file-name file))))
 

--- a/citar-file.el
+++ b/citar-file.el
@@ -85,8 +85,8 @@ separator that does not otherwise occur in citation keys."
 (defcustom citar-file-open-external-extensions '("html")
   "List of file extensions to be opened with external application.
 
-These are the extensions the `citar-file-open-external'
-will open, via `citar-file-open'."
+These are the extensions that `citar-file-open' will open via
+`citar-file-open-external'."
   :group 'citar
   :type '(repeat string))
 

--- a/citar-file.el
+++ b/citar-file.el
@@ -91,10 +91,9 @@ These are the extensions that `citar-file-open' will open via
   :type '(repeat (cons string
                        (choice
                         (function :tag "Open with function")
-                        (symbol :tag "Open with sytem default application"
+                        (symbol :tag "Open with system default application"
                                 system)
-                        (symbol :tag "Open with Emacs"
-                                default)
+                        (symbol :tag "Open with Emacs" default)
                         (string :tag "Open with customized application")))))
 
 
@@ -307,13 +306,13 @@ need to scan the contents of DIRS in this case."
   (if (assoc (file-name-extension file) citar-file-open-external-extension-alist)
       (let* ((fnext (file-name-extension file))
              (fnact (cdr (assoc fnext citar-file-open-external-extension-alist)))
-             (fnfull (expand-file-name file)))
+             (fnfull (expand-file-name file))
+             (w32p (and (eq system-type 'windows-nt)
+                        (fboundp 'w32-shell-execute))))
         (cond
          ((and (symbolp fnact) (eq fnact 'system))
           ;; Adapted from consult-file-externally.
-          (if (and (eq system-type 'windows-nt)
-                   (fboundp 'w32-shell-execute))
-              (w32-shell-execute "open" file)
+          (if w32p (w32-shell-execute "open" file)
             (call-process (pcase system-type
                             ('darwin "open")
                             ('cygwin "cygstart")
@@ -328,8 +327,10 @@ need to scan the contents of DIRS in this case."
           ;; if using `%s' for file name in the command
           (if (string-match-p (regexp-quote "%s") fnact)
               (let* ((args (split-string-and-unquote (format fnact fnfull))))
-                (apply 'start-process (concat fnext " viewer process") nil args))
-            (start-process (concat fnext " viewer process") nil fnact fnfull)))
+                (if w32p (apply 'w32-shell-execute "open" (append args '(0)))
+                  (apply 'start-process (concat fnext " viewer process") nil args)))
+            (if w32p (w32-shell-execute "open" fnact fnfull 0)
+              (start-process (concat fnext " viewer process") nil fnact fnfull))))
          (t (funcall citar-file-open-function fnfull))))
     (funcall citar-file-open-function (expand-file-name file))))
 


### PR DESCRIPTION
The new customization variable `citar-file-open-functions` is an alist from file extensions to functions used to open them. `citar-file-open` will now use this variable to decide how to open library files.

Fixes #507 