### PR TITLE
Add at-point function for org property drawers

### DIFF
--- a/citar-org.el
+++ b/citar-org.el
@@ -298,11 +298,26 @@ With optional argument FORCE, force the creation of a new ID."
 
 ;;;###autoload
 (defun citar-org-key-at-point ()
+  "Return key at point for org-cite citation-reference or property."
+  (or (citar-org--key-at-point)
+      (citar-org--prop-key-at-point)))
+
+(defun citar-org--key-at-point ()
   "Return key at point for org-cite citation-reference."
   (when-let ((reference (citar-org--reference-at-point)))
     (cons (org-element-property :key reference)
           (cons (org-element-property :begin reference)
                 (org-element-property :end reference)))))
+
+(defun citar-org--prop-key-at-point ()
+  "Return citekey at point, when in org property drawer.
+
+Citkey must be formatted as `@key'."
+  (when (and (equal (org-element-type (org-element-at-point)) 'node-property)
+             (org-in-regexp (concat "[[:space:]]" org-element-citation-key-re)))
+    (cons (substring (match-string 0) 2)
+          (cons (match-beginning 0)
+                (match-end 0)))))
 
 ;;;###autoload
 (defun citar-org-citation-at-point ()


### PR DESCRIPTION
Any reason not to do this?

It allows ` citar-org-key-at-point` to read `@key` strings in property drawers as citekeys (org won't recognize citations in property drawers), and so for `embark-act` etc to work on them.

It does not, however, work with `org-open-at-point`.

I guess one open question is what the allowed syntax there should be? I chose this because org-roam supports (for indexing), and because it avoids confusion about what's an org citation.

Close #684

cc @pprevos 