### PR TITLE
Unescape filenames in citar-file--parser-default

### DIFF
--- a/test/citar-file-test.el
+++ b/test/citar-file-test.el
@@ -15,11 +15,12 @@
   (should (equal '("foo" "bar") (delete-dups (citar-file--parser-default "foo;bar"))))
   (should (equal '("foo" "bar") (delete-dups (citar-file--parser-default " foo ; bar ; "))))
   (should (equal '("foo:bar" "baz") (delete-dups (citar-file--parser-default "foo:bar;baz"))))
+  (should (equal '("foo:bar" "baz") (delete-dups (citar-file--parser-default "foo:bar;;baz"))))
 
   ;; Test escaped delimiters
-  (should (equal '("foo\\;bar") (delete-dups (citar-file--parser-default "foo\\;bar"))))
+  (should (equal '("foo;bar" "foo\\;bar") (delete-dups (citar-file--parser-default "foo\\;bar"))))
   (should (equal '("foo" "bar\\") (delete-dups (citar-file--parser-default "foo;bar\\"))))
-  (should (equal '("foo\\;bar" "baz")
+  (should (equal '("foo;bar" "foo\\;bar" "baz")
                  (delete-dups (citar-file--parser-default "foo\\;bar;baz")))))
 
 (ert-deftest citar-file-test--parser-triplet ()


### PR DESCRIPTION
When encountering a filename with backslashes, consider both the original and unescaped versions.

Should fix #693.