### PR TITLE
github-ci: install all dependencies in the Eldev "prepare" step

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        eldev --color --trace prepare
+        eldev --color --trace prepare build
     - name: Byte-compile
       if: ${{ matrix.action == 'compile' }}
       run: |

--- a/Eldev
+++ b/Eldev
@@ -1,10 +1,10 @@
-; -*- mode: emacs-lisp; lexical-binding: t; no-byte-compile: t -*-
+; -*- mode: emacs-lisp; lexical-binding: t -*-
 ;; this and related files adapted from org-roam
 ;; explicitly set main file
 (setf eldev-project-main-file "citar.el")
 
-(eldev-use-package-archive 'gnu)
-(eldev-use-package-archive 'melpa-unstable)
+(eldev-use-package-archive 'gnu-elpa)
+(eldev-use-package-archive 'melpa)
 
 (eldev-use-plugin 'autoloads)
 


### PR DESCRIPTION
Make sure the Github CI workflow installs all needed dependencies in the separate "prepare" step, before the subsequent compile/test/lint steps. This was already the case for the declared package dependencies, but not for the additional build/test/lint dependences (auctex and embark) listed in the Eldev file.

Otherwise, when Eldev installs packages, it seems to delay adding already-installed packages to the Emacs load path. Org mode does not like this; the built-in version of Org gets loaded before the updated version from GNU ELPA, causing "Org version mismatch" errors.

Also update Eldev according to the suggestions of "eldev doctor"; make the Eldev file byte-compilable, use melpa instead of melpa-unstable, and use gnu-elpa instead of just gnu.