### PR TITLE
Don't use setf with buffer-substring

### DIFF
--- a/README.org
+++ b/README.org
@@ -64,11 +64,21 @@ This is the minimal configuration, and will work with any completing-read compli
 
 #+begin_src emacs-lisp
 (use-package citar
-  :bind (("C-c b" . citar-insert-citation)
-         :map minibuffer-local-map
-         ("M-b" . citar-insert-preset))
   :custom
   (citar-bibliography '("~/bib/references.bib")))
+#+end_src
+
+*** =citar-capf=
+
+This package includes a ~completion-at-point~ function to complete citation keys in the buffer, which you can configure like so:
+
+#+begin_src emacs-lisp
+(use-package citar
+  :custom
+  (citar-bibliography '("~/bib/references.bib"))
+  :hook
+  (LaTeX-mode . citar-capf-setup)
+  (org-mode . citar-capf-setup))
 #+end_src
 
 *** Embark
@@ -82,16 +92,6 @@ When using Embark, the Citar actions are generic, and work the same across org, 
   :after citar embark
   :no-require
   :config (citar-embark-mode))
-#+end_src
-
-*** =citar-capf=
-
-This package includes a ~completion-at-point~ function to complete citation keys in the buffer, which you can configure like so:
-
-#+begin_src emacs-lisp
-(use-package citar-capf
-  :init
-  (add-to-list 'completion-at-point-functions #'citar-capf))
 #+end_src
 
 *** Org-Cite

--- a/citar-capf.el
+++ b/citar-capf.el
@@ -76,18 +76,23 @@
             (lambda (_str _status)
               (insert))))))))
 
-  (defun citar-capf-annotate (citekey)
-    "Annotate a CITEKEY."
-    (let* ((author (citar-get-value "author" citekey))
-           (editor (citar-get-value "editor" citekey))
-           (title (citar-get-value "title" citekey)))
-      (concat
-       "   "
-       (truncate-string-to-width
-        (citar--shorten-names
-         (or author editor "")) 20 nil 32 t)
-       "  "
-       (truncate-string-to-width (or title "") 40 nil 32))))
+(defun citar-capf-annotate (citekey)
+  "Annotate a CITEKEY."
+  (let* ((author (citar-get-value "author" citekey))
+         (editor (citar-get-value "editor" citekey))
+         (title (citar-get-value "title" citekey)))
+    (concat
+     "   "
+     (truncate-string-to-width
+      (citar--shorten-names
+       (or author editor "")) 20 nil 32 t)
+     "  "
+     (truncate-string-to-width (or title "") 40 nil 32))))
+
+;;;###autoload
+(defun citar-capf-setup ()
+  "Add `citar-capf' to `completion-at-point-functions'."
+  (add-to-list 'completion-at-point-functions 'citar-capf))
 
 (provide 'citar-capf)
 ;;; citar-capf.el ends here

--- a/citar-org.el
+++ b/citar-org.el
@@ -404,12 +404,17 @@ or citation-reference."
       (error "You only have one reference; you cannot shift this"))
     (when (null index)
       (error "Nothing to shift here"))
-    (setf (buffer-substring (org-element-property :contents-begin current-citation)
-                            (org-element-property :contents-end current-citation))
-          (org-element-interpret-data
-           (citar-org-cite-swap
-            index
-            (if (eq 'left direction) (- index 1) (+ index 1)) refs)))
+    (let*
+        ((v1
+          (org-element-property :contents-begin current-citation))
+         (v2
+          (org-element-property :contents-end current-citation)))
+      (cl--set-buffer-substring v1 v2
+                                (org-element-interpret-data
+                                 (org-element-interpret-data
+                                  (citar-org-cite-swap
+                                   index
+                                   (if (eq 'left direction) (- index 1) (+ index 1)) refs)))))
     ;; Now get on the original ref.
     (let* ((newrefs (org-cite-get-references current-citation))
            (index
@@ -441,12 +446,15 @@ or citation-reference."
          (key (org-element-property :key ref))
          ;; TODO handle space delimiter elegantly.
          (pre (read-string "Prefix text: " (org-element-property :prefix ref)))
-         (post (read-string "Suffix text: " (org-element-property :suffix ref))))
-    (setf (buffer-substring (org-element-property :begin ref)
-                            (org-element-property :end ref))
-          (org-element-interpret-data
-           `(citation-reference
-             (:key ,key :prefix ,pre :suffix ,post))))))
+         (post (read-string "Suffix text: " (org-element-property :suffix ref)))
+         (v1
+          (org-element-property :begin ref))
+         (v2
+          (org-element-property :end ref)))
+    (cl--set-buffer-substring v1 v2
+                              (org-element-interpret-data
+                               `(citation-reference
+                                 (:key ,key :prefix ,pre :suffix ,post))))))
 
 ;; Load this last.
 

--- a/citar-org.el
+++ b/citar-org.el
@@ -402,6 +402,12 @@ or citation-reference."
 
     (when (= 1 (length refs))
       (error "You only have one reference; you cannot shift this"))
+    ;; TODO remove this when the shifting is updated to move to front or end of the list.
+    (when (or (and (equal index 0)
+                   (equal direction 'left))
+              (and (equal (+ 1 index) (length refs))
+                   (equal direction 'right)))
+      (error "You cannot shift the reference in this direction"))
     (when (null index)
       (error "Nothing to shift here"))
     (let*


### PR DESCRIPTION
Fix #729

--------

I don't understand this code well, and not sure this is the best solution, but it seems to work.

Here's the definition of `cl--set-buffer-substring`:

```elisp
(defun cl--set-buffer-substring (start end val)
  (save-excursion (delete-region start end)
          (goto-char start)
          (insert val)
          val))
```

Note: I uncovered a bug in the shift function that preceded this. If you try to move right, for example, when point is on the last reference, you will get a type error.

I think either it should do nothing but not trigger an obscure error, or move it to be the first reference.

I have implemented the former, but added a more useful error message.

Finally, I also added `citar-capf-setup` here.