### PR TITLE
Add formatting options for citar--shorten-names

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         emacs_version:
           - 27.2
-          - 28.1
+          - 28.2
           - snapshot
         action:
           - compile

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install Eldev
       run: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
     - name: Check out project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         eldev --color --trace prepare build

--- a/citar.el
+++ b/citar.el
@@ -1164,7 +1164,7 @@ replace last comma."
               (pos (citar--shorten-name-position tnamelist n))
               (suffix
                (cond
-                ;; if last name in the list, no suffix
+                ;; if last name in the list and we're truncating add et al.; otherwise, no suffix
                 ((equal pos tnamelength)
                  (if (< tnamelength namelength) " et al." ""))
                 ;; if second to last in the list, and ANDSTR, use that

--- a/citar.el
+++ b/citar.el
@@ -114,8 +114,8 @@ original entry, but also in entries specified in the field named
 by this variable."
   :group 'citar
   :type '(choice (const "crossref")
-                 (string :tag "Field name")
-                 (const :tag "Ignore cross-references" nil)))
+          (string :tag "Field name")
+          (const :tag "Ignore cross-references" nil)))
 
 (defcustom citar-additional-fields nil
   "A list of fields to add to parsed data.
@@ -141,8 +141,8 @@ The main and suffix templates are for candidate display, and note
 for the title field for new notes."
   :group 'citar
   :type  '(alist :key-type symbol
-                 :value-type string
-                 :options (main suffix preview note)))
+           :value-type string
+           :options (main suffix preview note)))
 
 (defcustom citar-ellipsis nil
   "Ellipsis string to mark ending of truncated display fields.
@@ -152,10 +152,10 @@ ellipsis will be used.  Otherwise, this should be a non-empty
 string specifying the ellipsis."
   :group 'citar
   :type '(choice (const :tag "Use `truncate-string-ellipsis'" t)
-                 (const :tag "No ellipsis" nil)
-                 (const "…")
-                 (const "...")
-                 (string :tag "Ellipsis string")))
+          (const :tag "No ellipsis" nil)
+          (const "…")
+          (const "...")
+          (string :tag "Ellipsis string")))
 
 (defcustom citar-format-reference-function
   #'citar-format-reference
@@ -171,8 +171,8 @@ function that takes a list of CITEKEYS and returns formatted
 references as a string."
   :group 'citar
   :type '(choice (function-item :tag "Use 'citar-template'" citar-format-reference)
-                 (function-item :tag "Use 'citeproc-el'" citar-citeproc-format-reference)
-                 (function :tag "Other")))
+          (function-item :tag "Use 'citeproc-el'" citar-citeproc-format-reference)
+          (function :tag "Other")))
 
 (defcustom citar-display-transform-functions
   ;; TODO change this name, as it might be confusing?
@@ -182,7 +182,7 @@ references as a string."
 All functions that match a particular field are run in order."
   :group 'citar
   :type '(alist :key-type   (choice (const t) (repeat string))
-                :value-type function))
+          :value-type function))
 
 (defcustom citar-symbols
   `((file  .  ("F" . " "))
@@ -196,9 +196,9 @@ To avoid alignment issues make sure that both the car and cdr of a symbol have
 the same width."
   :group 'citar
   :type '(alist :key-type symbol
-                :value-type (cons (string :tag "Present")
-                                  (string :tag "Absent"))
-                :options (file note link)))
+          :value-type (cons (string :tag "Present")
+                            (string :tag "Absent"))
+          :options (file note link)))
 
 (defcustom citar-symbol-separator " "
   "The padding between prefix symbols."
@@ -221,7 +221,7 @@ The action is used when no citation key is found at point.
 and nil means no action."
   :group 'citar
   :type '(radio (const :tag "Prompt" prompt)
-                (const :tag "Ignore" nil)))
+          (const :tag "Ignore" nil)))
 
 (defcustom citar-open-prompt (list #'citar-open #'citar-attach-files #'citar-open-note)
   "Always prompt to open files, notes, or links.
@@ -236,14 +236,14 @@ Otherwise, the value should be a list of command names that will
 always prompt to select."
   :group 'citar
   :type '(choice (const :tag "Always prompt" t)
-                 (const :tag "Prompt only for multiple resources" nil)
-                 (set :tag "Commands that prompt for multiple resources"
-                      (function-item citar-open)
-                      (function-item citar-open-files)
-                      (function-item citar-attach-files)
-                      (function-item citar-open-links)
-                      (function-item citar-open-notes)
-                      (function-item citar-open-note))))
+          (const :tag "Prompt only for multiple resources" nil)
+          (set :tag "Commands that prompt for multiple resources"
+               (function-item citar-open)
+               (function-item citar-open-files)
+               (function-item citar-attach-files)
+               (function-item citar-open-links)
+               (function-item citar-open-notes)
+               (function-item citar-open-note))))
 
 ;;;; File, note, and URL handling
 
@@ -251,9 +251,9 @@ always prompt to select."
   "Types of resources that `citar-open' offers to open."
   :group 'citar
   :type '(set (const :tag "Library files" :files)
-              (const :tag "Links" :links)
-              (const :tag "Notes" :notes)
-              (const :tag "Create notes" :create-notes)))
+          (const :tag "Links" :links)
+          (const :tag "Notes" :notes)
+          (const :tag "Create notes" :create-notes)))
 
 (defcustom citar-open-always-create-notes nil
   "Offer to create notes even for keys that already have notes.
@@ -266,10 +266,10 @@ Otherwise, the value should be a list of command names that will
 offer to create new notes unconditionally."
   :group 'citar
   :type '(choice (const :tag "Always offer to create notes" t)
-                 (const :tag "Create notes only if none exist" nil)
-                 (set :tag "Create notes for commands"
-                      (function-item citar-open)
-                      (function-item citar-open-notes))))
+          (const :tag "Create notes only if none exist" nil)
+          (set :tag "Create notes for commands"
+               (function-item citar-open)
+               (function-item citar-open-notes))))
 
 (defcustom citar-file-sources (list (list :items #'citar-file--get-from-file-field
                                           :hasitems #'citar-file--has-file-field)
@@ -289,13 +289,13 @@ Should be a list of plists, where each plist has the following properties:
 
 (defcustom citar-notes-sources
   `((citar-file .
-                ,(list :name "Notes"
-                       :category 'file
-                       :items #'citar-file--get-notes
-                       :hasitems #'citar-file--has-notes
-                       :open #'find-file
-                       :create #'citar-file--create-note
-                       :transform #'file-name-nondirectory)))
+     ,(list :name "Notes"
+            :category 'file
+            :items #'citar-file--get-notes
+            :hasitems #'citar-file--has-notes
+            :open #'find-file
+            :create #'citar-file--create-note
+            :transform #'file-name-nondirectory)))
   "The alist of notes backends available for configuration.
 
 The format of the cons should be (NAME . PLIST), where the
@@ -651,17 +651,17 @@ CATEGORY is one of:
   (cl-flet ((getresources (table) (when table
                                     (delete-dups (apply #'append (hash-table-values table)))))
             (keycands (type citekeys)
-                      (let ((format (citar-format--parse (citar--get-template 'completion)))
-                            (width (- (frame-width) 2)))
-                        (mapcar (lambda (key)
-                                  (let* ((entry (citar-get-entry key))
-                                         (cand (citar-format--entry format entry width
-                                                                    :ellipsis citar-ellipsis))
-                                         (keycand (citar--prepend-candidate-citekey key cand))
-                                         (target (cons 'citar-reference
-                                                       (propertize key 'citar--resource type))))
-                                    (propertize keycand 'multi-category target)))
-                                citekeys)))
+              (let ((format (citar-format--parse (citar--get-template 'completion)))
+                    (width (- (frame-width) 2)))
+                (mapcar (lambda (key)
+                          (let* ((entry (citar-get-entry key))
+                                 (cand (citar-format--entry format entry width
+                                                            :ellipsis citar-ellipsis))
+                                 (keycand (citar--prepend-candidate-citekey key cand))
+                                 (target (cons 'citar-reference
+                                               (propertize key 'citar--resource type))))
+                            (propertize keycand 'multi-category target)))
+                        citekeys)))
             (withtype (type cat cands) (when cands
                                          (cons cat (mapcar (lambda (cand)
                                                              (propertize cand 'citar--resource type))
@@ -1136,18 +1136,50 @@ getters for file, note, and link resources."
 
 ;;; Format and display field values
 
-(defun citar--shorten-names (names)
-  "Return a list of family names from a list of full NAMES.
+(defun citar--shorten-name-position (namelist name)
+  "Return NAME position in a NAMELIST."
+  (+ (seq-position namelist name) 1))
 
+(defun citar--shorten-name (name)
+  "Return family NAME in `family, given' string.
+
+Otherwise, return as is."
+  (car (split-string name ", ")))
+
+(defun citar--shorten-names (namestr &optional truncate andstr)
+  "Return a list of family names from a list of full NAMESTR.
 To better accommodate corporate names, this will only shorten
-personal names of the form \"family, given\"."
-  (when (stringp names)
-    (mapconcat
-     (lambda (name)
-       (if (eq 1 (length name))
-           (cdr (split-string name " "))
-         (car (split-string name ", "))))
-     (split-string names " and ") ", ")))
+personal names of the form \"family, given\".
+
+With an integer TRUNCATE, will shorten the list, and ANDSTR will
+replace last comma."
+  (let* ((namelist (split-string namestr " and "))
+         (namelength (length namelist))
+         (tnamelist (seq-take namelist (or truncate namelength)))
+         (tnamelength (length tnamelist)))
+    (cond ((equal tnamelength 1)
+           (citar--shorten-name (car tnamelist)))
+          ((equal tnamelength 2)
+           (concat (citar--shorten-name (car tnamelist))
+                   (if andstr (concat " " andstr) ",") " "
+                   (citar--shorten-name (cadr tnamelist))))
+          (t
+           (mapconcat
+            (lambda (n)
+              (let* ((shortname (citar--shorten-name n))
+                     (pos (citar--shorten-name-position tnamelist n))
+                     (suffix
+                      (cond
+                       ;; if last name in the list, no suffix
+                       ((equal pos tnamelength)
+                        (if (< tnamelength namelength) " et al" ""))
+                       ;; if second to last in the list, and ANDSTR, use that
+                       ((and andstr (equal pos (- tnamelength 1)))
+                        (concat " " andstr " "))
+                       ;; otherwise, use a comma
+                       (t ", "))))
+                (concat shortname suffix)))
+            tnamelist "")))))
 
 (defun citar--fields-for-format (template)
   "Return list of fields for TEMPLATE."
@@ -1198,9 +1230,9 @@ personal names of the form \"family, given\"."
 (defun citar--symbols-string (has-files has-note has-link)
   "String for display from booleans HAS-FILES HAS-LINK HAS-NOTE."
   (cl-flet ((thing-string (has-thing thing-symbol)
-                          (if has-thing
-                              (cadr (assoc thing-symbol citar-symbols))
-                            (cddr (assoc thing-symbol citar-symbols)))))
+              (if has-thing
+                  (cadr (assoc thing-symbol citar-symbols))
+                (cddr (assoc thing-symbol citar-symbols)))))
     (seq-reduce (lambda (constructed newpart)
                   (let* ((str (concat constructed newpart
                                       citar-symbol-separator))

--- a/citar.el
+++ b/citar.el
@@ -271,10 +271,11 @@ offer to create new notes unconditionally."
                (function-item citar-open)
                (function-item citar-open-notes))))
 
-(defcustom citar-file-sources (list (list :items #'citar-file--get-from-file-field
-                                          :hasitems #'citar-file--has-file-field)
-                                    (list :items #'citar-file--get-library-files
-                                          :hasitems #'citar-file--has-library-files))
+(defcustom citar-file-sources
+  (list (list :items #'citar-file--get-from-file-field
+              :hasitems #'citar-file--has-file-field)
+        (list :items #'citar-file--get-library-files
+              :hasitems #'citar-file--has-library-files))
   "List of backends used to get library files for bibliography references.
 
 Should be a list of plists, where each plist has the following properties:

--- a/citar.el
+++ b/citar.el
@@ -1157,29 +1157,22 @@ replace last comma."
          (namelength (length namelist))
          (tnamelist (seq-take namelist (or truncate namelength)))
          (tnamelength (length tnamelist)))
-    (cond ((equal tnamelength 1)
-           (citar--shorten-name (car tnamelist)))
-          ((equal tnamelength 2)
-           (concat (citar--shorten-name (car tnamelist))
-                   (if andstr (concat " " andstr) ",") " "
-                   (citar--shorten-name (cadr tnamelist))))
-          (t
-           (mapconcat
-            (lambda (n)
-              (let* ((shortname (citar--shorten-name n))
-                     (pos (citar--shorten-name-position tnamelist n))
-                     (suffix
-                      (cond
-                       ;; if last name in the list, no suffix
-                       ((equal pos tnamelength)
-                        (if (< tnamelength namelength) " et al" ""))
-                       ;; if second to last in the list, and ANDSTR, use that
-                       ((and andstr (equal pos (- tnamelength 1)))
-                        (concat " " andstr " "))
-                       ;; otherwise, use a comma
-                       (t ", "))))
-                (concat shortname suffix)))
-            tnamelist "")))))
+    (mapconcat
+     (lambda (n)
+       (let* ((shortname (citar--shorten-name n))
+              (pos (citar--shorten-name-position tnamelist n))
+              (suffix
+               (cond
+                ;; if last name in the list, no suffix
+                ((equal pos tnamelength)
+                 (if (< tnamelength namelength) " et al." ""))
+                ;; if second to last in the list, and ANDSTR, use that
+                ((and andstr (equal pos (- tnamelength 1)))
+                 (concat " " andstr " "))
+                ;; otherwise, use a comma
+                (t ", "))))
+         (concat shortname suffix)))
+     tnamelist "")))
 
 (defun citar--fields-for-format (template)
   "Return list of fields for TEMPLATE."


### PR DESCRIPTION
Add an optional TRUNCATE and ANDSTR args for this function.

Addresses #694

-------

Is this output all correct?

```elisp
ELISP> (citar--shorten-names "Doe, J and Smith, N and Jones, K and Lamb, H")
"Doe, Smith, Jones, Lamb"
ELISP> (citar--shorten-names "Doe, J and Smith, N and Jones, K and Lamb, H" 3)
"Doe, Smith, Jones et al"
ELISP> (citar--shorten-names "Doe, J and Smith, N and Jones, K and Lamb, H" 3 "and")
"Doe, Smith and Jones et al"
```