### PR TITLE
Fixes to citar--shorten-names

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -1157,9 +1157,9 @@ replace last comma."
          (namelength (length namelist))
          (tnamelist (seq-take namelist (or truncate namelength)))
          (tnamelength (length tnamelist)))
-    (cond ((equal tnamelength 1)
+    (cond ((equal namelength 1)
            (citar--shorten-name (car tnamelist)))
-          ((equal tnamelength 2)
+          ((equal namelength 2)
            (concat (citar--shorten-name (car tnamelist))
                    (if andstr (concat " " andstr) ",") " "
                    (citar--shorten-name (cadr tnamelist))))
@@ -1172,7 +1172,7 @@ replace last comma."
                       (cond
                        ;; if last name in the list, no suffix
                        ((equal pos tnamelength)
-                        (if (< tnamelength namelength) " et al" ""))
+                        (if (< tnamelength namelength) " et al." ""))
                        ;; if second to last in the list, and ANDSTR, use that
                        ((and andstr (equal pos (- tnamelength 1)))
                         (concat " " andstr " "))

--- a/citar.el
+++ b/citar.el
@@ -1160,9 +1160,9 @@ replace last comma."
     (cond ((equal namelength 1)
            (citar--shorten-name (car tnamelist)))
           ((equal namelength 2)
-           (concat (citar--shorten-name (car tnamelist))
+           (concat (citar--shorten-name (car namelist))
                    (if andstr (concat " " andstr) ",") " "
-                   (citar--shorten-name (cadr tnamelist))))
+                   (citar--shorten-name (cadr namelist))))
           (t
            (mapconcat
             (lambda (n)


### PR DESCRIPTION
When I use `truncate` as 1 or 2, it does  not show "et al.", which should always show when `namelength` > `truncate`. 

Changing `tnamelength` to `namelength` in the conditional fixes the issue. 

Minor point, "et al" needs to be "et al.".

I used a citation with 7 authors for testing: https://doi.org/10.1038/s41545-022-00208-8
