### PR TITLE
Enhance citar-display-transform-functions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,6 +32,10 @@ jobs:
         exclude:
           - emacs_version: snapshot
             action: compile
+          - emacs_version: 27.2
+            action: lint
+          - emacs_version: 28.2
+            action: lint
     steps:
     - name: Set up Emacs ${{matrix.emacs_version}}
       uses: purcell/setup-emacs@master


### PR DESCRIPTION
Modify the defcustom so that transform functions can be specified by template, and adjust `citar-get-display-value` accordingly by adding an optional "template" argument.

So default works the same, but you can now also do this:

```elisp
ELISP> (citar-get-display-value '("author" "editor") "francis2012" 'notes)
"Francis, Giles-Corti & Wood et al."
```

Close #694

Also, disable linting on everything before Emacs snapshot, since there are recent changes in indenting rules that cannot be accounted for cross-version.

-----

Aside: I'm confused on how to clear the candidate cache, so I can force regeneration. This does not work, for example:

```elisp
(clrhash (citar--format-candidates))
```

If you have time over the next few days, can you take a look at this @aikrahguzar @roshanshariff?

EDIT: I think I'm missing a piece here ATM, which is the template connection. But I'm tired, so will need to look at it again later. I mainly want confirmation this is a good idea though.

EDIT 2: took another look this morning. I think `citar-format--entry` is where this would be, but it currently takes a `format` rather the symbol for it. So will need to think about that.