### PR TITLE
Allow transform modifiers in templates

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,6 +32,10 @@ jobs:
         exclude:
           - emacs_version: snapshot
             action: compile
+          - emacs_version: 28.2
+            action: lint
+          - emacs_version: 27.2
+            action: lint
     steps:
     - name: Set up Emacs ${{matrix.emacs_version}}
       uses: purcell/setup-emacs@master

--- a/README.org
+++ b/README.org
@@ -180,10 +180,10 @@ Here's the default value:
 
 #+begin_src emacs-lisp
 (setq citar-templates
-      '((main . "${author editor:30}     ${date year issued:4}     ${title:48}")
+      '((main . "${author editor:30%sn}     ${date year issued:4}     ${title:48}")
         (suffix . "          ${=key= id:15}    ${=type=:12}    ${tags keywords:*}")
-        (preview . "${author editor} (${year issued date}) ${title}, ${journal journaltitle publisher container-title collection-title}.\n")
-        (note . "Notes on ${author editor}, ${title}")))
+        (preview . "${author editor%etal} (${year issued date}) ${title}, ${journal journaltitle publisher container-title collection-title}.\n")
+        (note . "Notes on ${author editor:%etal}, ${title}")))
 #+end_src
 
 Note:
@@ -192,6 +192,8 @@ Note:
 2. If you plan to use CSL JSON at all, you can and should include CSL JSON variables names where appropriate as such options. The default main template dates field demonstrates this.
 3. The asterisk signals to the formatter to use available space for the column.
 4. The note template does not take widths, as formatting is inline there rather than columnar.
+5. The ~%~ character preceeds a token defined as a key in ~citar-display-transform-functions~, whose value is a list of functions and optional arguments.
+   Note that if you include this, if you include this and a width specification, it must come after the width.
 
 *** Icons
 


### PR DESCRIPTION
Modify:

* `citar-display-transform-functions` so it becomes a list of shortcuts to include in template specs (like `"${author:20%etal}"` where `etal` is the key that then points to a list of a function symbol and optional arguments).

* `citar-get-display-value` so it allows an optional transform function

* `citar-format--parse` to include transform list

* formatting functions to properly integrate the above

Close #694

-----

This is an alternative to #734; I think easier to implement and configure, and more flexible.

I think it all works, and **unless I hear otherwise, I'll likely merge it tomorrow, March 13**.

EDIT: I got sidetracked by a stupid variable declaration bug; now fixed.

@andersjohansson @pprevos - any feedback on this? I think you were, or may be, interested in such a feature.

PS - It has occurred to me that perhaps when strings are transformed, the original value should still be included as hidden (making use of display vs hidden properties)?

```elisp
(propertize "Doe, J and Jones, K and Smith, L" 'hidden t 'display "Doe et al.")
```