### PR TITLE
Don't throw out field data; use cache for citeproc

### DIFF
--- a/citar-cache.el
+++ b/citar-cache.el
@@ -227,9 +227,7 @@ use the value returned by that function. This argument is
 provided in case that function has already been called so that
 its return value can be reused.
 
-Only the bibliography fields listed in the :fields value of PROPS
-are parsed. After updating, the `props' slot of BIB is set to
-PROPS."
+After updating, the `props' slot of BIB is set to PROPS."
   (let* ((filename (citar-cache--bibliography-filename bib))
          (props (or props (citar-cache--get-bibliography-props filename)))
          (entries (citar-cache--bibliography-entries bib))
@@ -238,7 +236,7 @@ PROPS."
     (message "%s..." messagestr)
     (redisplay)                         ; Make sure message is displayed before Emacs gets busy parsing
     (clrhash entries)
-    (parsebib-parse filename :entries entries :fields (plist-get props :fields))
+    (parsebib-parse filename :entries entries)
     (setf (citar-cache--bibliography-props bib) props)
     (citar-cache--preformat-bibliography bib)
     (message "%s...done (%.3f seconds)" messagestr (float-time (time-since starttime)))))


### PR DESCRIPTION
Can you take a look at this @andras-simonyi @andersjohansson?

It's a simple solution to the problem we've previously discussed, and an alternative to #710. I mostly stole code from `org-cite-csl-activate`!

But this should:

1. fix #702
2. provide all the advantages of using the citar cache
3. remove the potential limitation noted in the `org-cite-csl-activate` [README](https://github.com/andras-simonyi/org-cite-csl-activate#using-the-citar-cache-for-retrieving-bibliographic-entries).

The only problem I can potentially see is _maybe_ it slows down initial loading of libraries a little, and uses a bit more memory. But I doubt it's a significant impact. And if it ever were, we could always add a defcustom so people could turn it off?

@andras-simonyi - not sure what you think about this, but one possibility is you can use the functions here instead, since you're already loading `citar` when available, and remove some code in `org-cite-csl-activate` in the process?

cc @benthamite