### PR TITLE
Add optional affixation symbol for currently cited references

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -253,6 +253,12 @@ in some cases when using icons.")
    :function #'citar-has-notes
    :tag "has:notes"))
 
+(defvar citar-indicator-cited
+  (citar-indicator-create
+   :symbol "C"
+   :function #'citar-is-cited
+   :tag "is:cited"))
+
 ;; Indicator config
 
 (defvar citar-indicators
@@ -1310,6 +1316,17 @@ replace last comma."
                      (list citar-crossref-variable))
                  ,@(mapcar (lambda (field) (symbol-name (car field))) citar-link-fields)
                  . ,citar-additional-fields)))
+
+;;; Affixation for currently cited references
+(defvar citar--cited-references (make-hash-table :test #'equal)
+  "Hash table of references cited in current buffer/project.")
+
+(defun citar-is-cited ()
+  "Return a function for checking whether CITEKEY is cited.
+Just looks for CITEKEY in ‘citar--cited-references’."
+  (lambda (citekey)
+    (gethash citekey
+             citar--cited-references)))
 
 ;;; Affixations and annotations
 


### PR DESCRIPTION
It's helpful to see what you’ve already cited in the current document.This is something I have missed from my earlier system that extended org-zotxt (before org-cite).

I'm not sure if you want to include something like this, and it is not finished for anything more than org.

An implementation for fetching cite keys in org-mode is included, with configuration for fetching in narrowed buffer or not, and from several org buffers.

Optional grouping by currently cited is also included, however, this seems to interfere with the multi-selection display based on grouping.

(Took some time to go through my citar config and this branch today)