### PR TITLE
Indicator for cited references, re-using major-mode `list-keys` function

### DIFF
--- a/citar-file.el
+++ b/citar-file.el
@@ -326,7 +326,8 @@ extensions in `citar-file-note-extensions'."
 (defun citar-file--has-notes ()
   "Return predicate testing whether cite key has associated notes."
   (let ((notes (citar-file--get-notes)))
-    (unless (hash-table-empty-p notes)
+    (if (hash-table-empty-p notes)
+        (lambda (_citekey) nil)
       (lambda (citekey) (and (gethash citekey notes) t)))))
 
 (defun citar-file--create-note (key entry)

--- a/citar.el
+++ b/citar.el
@@ -253,6 +253,12 @@ in some cases when using icons.")
    :function #'citar-has-notes
    :tag "has:notes"))
 
+(defvar citar-indicator-cited
+  (citar-indicator-create
+   :symbol "C"
+   :function #'citar-is-cited
+   :tag "is:cited"))
+
 ;; Indicator config
 
 (defvar citar-indicators
@@ -620,6 +626,8 @@ FILTER: if non-nil, should be a predicate function taking a
   (citar-select-ref :filter (citar-has-file))"
   (let* ((candidates (or (citar--format-candidates)
                          (user-error "No bibliography set")))
+         (_cited (when (memq citar-indicator-cited citar-indicators)
+                   (citar--populate-cited-hash)))
          (chosen (if (and multiple citar-select-multiple)
                      (citar--select-multiple "References: " candidates
                                              filter 'citar-history citar-presets)
@@ -1310,6 +1318,23 @@ replace last comma."
                      (list citar-crossref-variable))
                  ,@(mapcar (lambda (field) (symbol-name (car field))) citar-link-fields)
                  . ,citar-additional-fields)))
+
+;;; Affixation for currently cited references
+(defvar citar--cited-references (make-hash-table :test #'equal)
+  "Hash table of references cited in current buffer/project.")
+
+(defun citar-is-cited ()
+  "Return a function for checking whether CITEKEY is cited.
+Just looks for CITEKEY in ‘citar--cited-references’."
+  (lambda (citekey)
+    (gethash citekey
+             citar--cited-references)))
+
+(defun citar--populate-cited-hash ()
+  "Parse buffer to populate ‘citar--cited-references’."
+  (clrhash citar--cited-references)
+  (cl-loop for key in (citar--major-mode-function 'list-keys #'ignore)
+           do (puthash key t citar--cited-references)))
 
 ;;; Affixations and annotations
 


### PR DESCRIPTION
This is a simpler variant of #744. 

I am not sure about whether it is smart to transform a list to a hash table in this way, compared to generating a hash-table from the beginning. A hash table should be most suitable for lookup (`citar-is-cited`) though.