### PR TITLE
fix(indicators): add `padding` slot

### DIFF
--- a/README.org
+++ b/README.org
@@ -227,7 +227,22 @@ Here's a screenshot using this configuration, which removes the links indicator,
 #+name: fig-indicators
 [[images/indicators.png]]
 
-You can create your own indicators, of course, though keep in mind the included predicate functions must be performance-optimized, since the completion UI runs them on your entire library every time you open it.
+You can create your own indicators, of course.
+Here's an example indicator definition incorporating icons:
+
+#+begin_src emacs-lisp
+(defvar citar-indicator-notes-icons
+  (citar-indicator-create
+   :symbol (all-the-icons-material
+            "speaker_notes"
+            :face 'all-the-icons-blue
+            :v-adjust -0.3)
+   :function #'citar-has-notes
+   :padding " "
+   :tag "has:notes"))
+#+end_src
+
+Keep in mind, however, the included predicate functions must be performance-optimized, since the completion UI runs them on your entire library every time you open it.
 
 ** Test Script
     :PROPERTIES:

--- a/citar.el
+++ b/citar.el
@@ -217,7 +217,13 @@ candidate predicate function will return non-nil.")
   :type string
   :documentation
   "The symbol string to use in the UI when predicate function returns non-nil.")
+ (padding
+  " "
+  :type string
+  :documentation
+  "String to add to the right side of the indicator, for proper padding and such.")
  (emptysymbol
+  ;; REVIEW we may not need this, so perhaps remove?
   " "
   :documentation
   "The symbol to use in the UI when predicate function returns nil. Can be useful
@@ -279,10 +285,12 @@ the same width."
 
 (defcustom citar-symbol-separator " "
   "The padding between prefix symbols."
+  ;; DEPRECATED
   :group 'citar
   :type 'string)
 
 (make-obsolete 'citar-symbols nil "1.4")
+(make-obsolete 'citar-symbol-separator nil "1.4")
 
 ;;;; Citar actions and other miscellany
 
@@ -866,13 +874,15 @@ visible in the completion UI."
              (matchtagp (string-match-p matchtext candidate))
              (sym (citar-indicator-symbol ispec))
              (emptysym (citar-indicator-emptysymbol ispec))
+             (padding (citar-indicator-padding ispec))
              (str (concat
                    constructed
                    (if matchtagp sym emptysym)
-                   citar-symbol-separator))
+                   padding))
              (pos (length str)))
         (put-text-property (- pos 1) pos 'display
-                           (cons 'space (list :align-to (string-width str)))
+                           (cons 'space
+                                 (list :align-to (string-width str)))
                            str)
         str))
     citar-indicators ""))

--- a/test/manual/citar.el
+++ b/test/manual/citar.el
@@ -28,6 +28,7 @@
 
 ;; load the test bib file
 (setq citar-bibliography '("../test.bib"))
+(setq citar-notes-paths '("../"))
 
 (setq vertico-count 20)
 


### PR DESCRIPTION
* add `padding` to `citar-indicator`, set to default value of 1
* incorporate into `citar--make-indicator-symbols`
* deprecate `citar-symbol-separator`
* update README

Close: #759

---------------

I think I fixed it.

![image](https://user-images.githubusercontent.com/1134/227266811-e4b6dbe1-6e6c-45cd-87c3-c05034902a89.png)

So basically, there's no longer a global variable for the separator; instead it's defined in the `citar-indicator` specs, with a default of 1.

If you two can either test, or at least check the basic logic, that'd be great.

@gwbrck @robmoss

Hmm .. as I look at documentation, this seems a bit odd:

```elisp
   :symbolwidth 2
   :emptysymbol "  "
```

The latter is required, because one might want to use an icon also.

But maybe they should be consistent? Probably not, since they serve different purposes?