### PR TITLE
feat(indicators): add cited

### DIFF
--- a/README.org
+++ b/README.org
@@ -212,6 +212,7 @@ By default, it includes plain text indicators for, each of which indicates the p
 - notes
 - library files
 - links
+- cited (for references cited in the current buffer)
 
 For other indicators, see the [[https://github.com/emacs-citar/citar/wiki/Indicators][wiki]].
 

--- a/citar.el
+++ b/citar.el
@@ -887,6 +887,15 @@ visible in the completion UI."
                    (if matchtagp sym emptysym)
                    padding))
              (pos (length str)))
+        ;; See https://github.com/emacs-citar/citar/issues/764 for explanation of what this code is doing.
+        ;;
+        ;; We say that the last character of the padding should be replaced by a space which stretches to the
+        ;; position we want to.
+        ;;
+        ;; So for example if the icon has string width 1 but occupies 0.9 the space will stretch to occupy 1.1
+        ;; and if the icon occupies 1.5 it will shrink to occupy 0.5.
+        ;;
+        ;; Emacs 29 has `vtable', which we might use here in the future as well.
         (put-text-property (- pos 1) pos 'display
                            (cons 'space
                                  (list :align-to (string-width str)))

--- a/citar.el
+++ b/citar.el
@@ -259,12 +259,19 @@ in some cases when using icons.")
    :function #'citar-has-notes
    :tag "has:notes"))
 
+(defvar citar-indicator-cited
+  (citar-indicator-create
+   :symbol "C"
+   :function #'citar-is-cited
+   :tag "is:cited"))
+
 ;; Indicator config
 
 (defvar citar-indicators
   (list citar-indicator-links
         citar-indicator-files
-        citar-indicator-notes))
+        citar-indicator-notes
+        citar-indicator-cited))
 
 (defcustom citar-symbols
   `((file  .  ("F" . " "))
@@ -1113,6 +1120,13 @@ nil, return nil."
                                    (when-let ((fieldvalue (citar-get-value fieldname entry)))
                                      (push (format urlformat fieldvalue) keylinks))))
                                (nreverse keylinks)))))))
+
+(defun citar-is-cited ()
+  "Return function to check if reference is cited in buffer."
+  (let ((iscited
+         (citar--major-mode-function 'list-keys #'ignore)))
+    (lambda (citekey)
+      (member citekey iscited))))
 
 (defun citar-has-files ()
   "Return predicate testing whether entry has associated files.


### PR DESCRIPTION
@andersjohansson - can you give this a try? 

It's just a few lines (no cache or hash table), but works for me.

```elisp
(defun citar-is-cited ()
  "Return function to check if reference is cited in buffer."
  (let ((iscited
         (citar--major-mode-function 'list-keys #'ignore)))
    (lambda (citekey)
      (member citekey iscited))))
```

![image](https://user-images.githubusercontent.com/1134/227501723-65af89bd-b47b-436d-84bb-6e7ee92c1840.png)

My test file was small though.

If this is good to go, I can merge it.

I gave co-author credit on the commit :-)

We can then later think of other enhancements as and if needed (like possibly extending `'list-keys` beyond the immediate buffer, or optimizing performance).

PS - `'list-keys` was originally added to allow exporting of local bib files.