### PR TITLE
Upgrade citar-org-update-pre-suffix to iterate through all references in citation

### DIFF
--- a/citar-org.el
+++ b/citar-org.el
@@ -442,14 +442,19 @@ or citation-reference."
 
 (defun citar-org--update-prefix-suffix ()
   "Change the prefix and suffix text of the reference at point."
-  (let* ((datum (org-element-context))
-         (datum-type (org-element-type datum))
-         (ref (if (eq datum-type 'citation-reference) datum
-                (error "Not on a citation reference")))
+  (let* ((ref (org-element-context))
          (key (org-element-property :key ref))
-         ;; TODO handle space delimiter elegantly.
-         (pre (read-string "Prefix text: " (org-element-property :prefix ref)))
-         (post (read-string "Suffix text: " (org-element-property :suffix ref)))
+         (citekey-str (propertize key 'face 'mode-line-emphasis))
+         ;; TODO Unsure if we want to process pre at all
+         (pre (read-string (concat "Prefix for " citekey-str ": ")
+                           (org-element-property :prefix ref)))
+         (post (string-trim-left        ; Remove leading whitespace
+                (read-string (concat "Suffix for " citekey-str ": ")
+                             (org-element-property :suffix ref))))
+         ;; Change post to have one space prior to the user-inputted suffix, unless post is already empty or
+         ;; just whitespace
+         (post-processed
+          (concat (unless (string-empty-p post) " ") post))
          (v1
           (org-element-property :begin ref))
          (v2
@@ -457,7 +462,7 @@ or citation-reference."
     (cl--set-buffer-substring v1 v2
                               (org-element-interpret-data
                                `(citation-reference
-                                 (:key ,key :prefix ,pre :suffix ,post))))))
+                                 (:key ,key :prefix ,pre :suffix ,post-processed))))))
 
 (defun citar-org-update-prefix-suffix (&optional arg)
   "Change the prefix and suffix text of the reference at point.

--- a/citar-org.el
+++ b/citar-org.el
@@ -487,10 +487,12 @@ If point is not on a reference or citation, throw an error."
           ;; cannot simply use the initial value of refs all throughout
           (dotimes (ref-index (length refs))
             (citar-org--update-prefix-suffix (nth ref-index refs))
-            ;; Update refs since the begins and ends for the following reference could have changed when
+            ;; Update refs since the begins and ends for the following references could have changed when
             ;; adding a prefix and/or suffix
             (setq refs (org-cite-get-references
-                        (org-element-property :parent (org-element-context)))))
+                        (if citation-p
+                            (org-element-context)
+                          (org-element-property :parent (org-element-context))))))
         (citar-org--update-prefix-suffix (org-element-context))))))
 
 ;; Load this last.

--- a/citar-org.el
+++ b/citar-org.el
@@ -80,7 +80,7 @@ Each function takes one argument, a citation."
     (define-key map (kbd "C-c C-x k") (cons "kill citation" #'citar-org-kill-citation))
     (define-key map (kbd "S-<left>") (cons "shift left" #'citar-org-shift-reference-left))
     (define-key map (kbd "S-<right>") (cons "shift right" #'citar-org-shift-reference-right))
-    (define-key map (kbd "M-p") (cons "update prefix/suffix" #'citar-org-update-pre-suffix))
+    (define-key map (kbd "M-p") (cons "update prefix/suffix" #'citar-org-update-prefix-suffix))
     map)
   "Keymap for interacting with org citations at point.")
 
@@ -440,7 +440,7 @@ or citation-reference."
   (let ((datum (org-element-context)))
     (citar-org--shift-reference datum 'right)))
 
-(defun citar-org--update-pre-suffix ()
+(defun citar-org--update-prefix-suffix ()
   "Change the prefix and suffix text of the reference at point."
   (let* ((datum (org-element-context))
          (datum-type (org-element-type datum))
@@ -459,7 +459,7 @@ or citation-reference."
                                `(citation-reference
                                  (:key ,key :prefix ,pre :suffix ,post))))))
 
-(defun citar-org-update-pre-suffix (&optional arg)
+(defun citar-org-update-prefix-suffix (&optional arg)
   "Change the prefix and suffix text of the reference at point.
 If given ARG, change the prefix and suffix for every reference in
 the citation at point."
@@ -472,12 +472,12 @@ the citation at point."
       (if (or arg citation-p)
           (dotimes (ref-index (length refs))
             (goto-char (org-element-property :begin (nth ref-index refs)))
-            (citar-org--update-pre-suffix)
+            (citar-org--update-prefix-suffix)
             ;; Update refs since the begins and ends for the following reference could have changed when
             ;; adding a prefix and/or suffix
             (setq refs (org-cite-get-references
                         (org-element-property :parent (org-element-context)))))
-        (citar-org--update-pre-suffix)))))
+        (citar-org--update-prefix-suffix)))))
 
 ;; Load this last.
 

--- a/citar-org.el
+++ b/citar-org.el
@@ -442,7 +442,9 @@ or citation-reference."
 
 (defun citar-org--update-prefix-suffix ()
   "Change the prefix and suffix text of the reference at point."
-  (let* ((ref (org-element-context))
+  (let* ((datum (org-element-context))
+         (ref-p (eq 'citation-reference (org-element-type datum)))
+         (ref (if ref-p datum (error "Not on a reference")))
          (key (org-element-property :key ref))
          (citekey-str (propertize key 'face 'mode-line-emphasis))
          ;; TODO Unsure if we want to process pre at all
@@ -467,11 +469,17 @@ or citation-reference."
 (defun citar-org-update-prefix-suffix (&optional arg)
   "Change the prefix and suffix text of the reference at point.
 If given ARG, change the prefix and suffix for every reference in
-the citation at point."
+the citation at point.
+
+If point is not on a reference or citation, throw an error."
   (interactive "P")
   (let* ((datum (org-element-context))
          (citation-p (eq 'citation (org-element-type datum)))
-         (current-citation (if citation-p datum (org-element-property :parent datum)))
+         (ref-p (eq 'citation-reference (org-element-type datum)))
+         (current-citation (cond
+                            (citation-p datum)
+                            (ref-p (org-element-property :parent datum))
+                            (t (error "Not on a citation or reference"))))
          (refs (org-cite-get-references current-citation)))
     (save-excursion
       (if (or arg citation-p)

--- a/citar-org.el
+++ b/citar-org.el
@@ -447,16 +447,18 @@ DATUM should be a reference, otherwise throw an error."
          (ref (if ref-p datum (error "Not on a reference")))
          (key (org-element-property :key ref))
          (citekey-str (propertize key 'face 'mode-line-emphasis))
-         ;; TODO Unsure if we want to process pre at all
-         (pre (read-string (concat "Prefix for " citekey-str ": ")
-                           (org-element-property :prefix ref)))
-         (post (string-trim-left        ; Remove leading whitespace
-                (read-string (concat "Suffix for " citekey-str ": ")
-                             (org-element-property :suffix ref))))
-         ;; Change post to have one space prior to the user-inputted suffix, unless post is already empty or
-         ;; just whitespace
-         (post-processed
-          (concat (unless (string-empty-p post) " ") post))
+         (pre (org-element-interpret-data (org-element-property :prefix ref)))
+         (post (org-element-interpret-data (org-element-property :suffix ref)))
+         ;; TODO Unsure if we want to process prefix at all
+         (prefix (read-string (concat "Prefix for " citekey-str ": ")
+                              (string-trim pre)))
+         (suffix (string-trim-left        ; Remove leading whitespace
+                  (read-string (concat "Suffix for " citekey-str ": ")
+                               (string-trim post))))
+         ;; Change suffix to have one space prior to the user-inputted suffix, unless suffix is already empty
+         ;; or just whitespace
+         (suffix-processed
+          (concat (unless (string-empty-p suffix) " ") suffix))
          (v1
           (org-element-property :begin ref))
          (v2
@@ -464,7 +466,7 @@ DATUM should be a reference, otherwise throw an error."
     (cl--set-buffer-substring v1 v2
                               (org-element-interpret-data
                                `(citation-reference
-                                 (:key ,key :prefix ,pre :suffix ,post-processed))))))
+                                 (:key ,key :prefix ,prefix :suffix ,suffix-processed))))))
 
 (defun citar-org-update-prefix-suffix (&optional arg)
   "Change the prefix and suffix text of the reference at point.

--- a/citar-org.el
+++ b/citar-org.el
@@ -440,10 +440,10 @@ or citation-reference."
   (let ((datum (org-element-context)))
     (citar-org--shift-reference datum 'right)))
 
-(defun citar-org--update-prefix-suffix ()
-  "Change the prefix and suffix text of the reference at point."
-  (let* ((datum (org-element-context))
-         (ref-p (eq 'citation-reference (org-element-type datum)))
+(defun citar-org--update-prefix-suffix (datum)
+  "Change the prefix and suffix text of the DATUM at point.
+DATUM should be a reference, otherwise throw an error."
+  (let* ((ref-p (eq 'citation-reference (org-element-type datum)))
          (ref (if ref-p datum (error "Not on a reference")))
          (key (org-element-property :key ref))
          (citekey-str (propertize key 'face 'mode-line-emphasis))
@@ -483,14 +483,15 @@ If point is not on a reference or citation, throw an error."
          (refs (org-cite-get-references current-citation)))
     (save-excursion
       (if (or arg citation-p)
+          ;; We use dotimes over dolist because the buffer changes as we iterate through the list, meaning we
+          ;; cannot simply use the initial value of refs all throughout
           (dotimes (ref-index (length refs))
-            (goto-char (org-element-property :begin (nth ref-index refs)))
-            (citar-org--update-prefix-suffix)
+            (citar-org--update-prefix-suffix (nth ref-index refs))
             ;; Update refs since the begins and ends for the following reference could have changed when
             ;; adding a prefix and/or suffix
             (setq refs (org-cite-get-references
                         (org-element-property :parent (org-element-context)))))
-        (citar-org--update-prefix-suffix)))))
+        (citar-org--update-prefix-suffix (org-element-context))))))
 
 ;; Load this last.
 

--- a/citar-org.el
+++ b/citar-org.el
@@ -440,11 +440,8 @@ or citation-reference."
   (let ((datum (org-element-context)))
     (citar-org--shift-reference datum 'right)))
 
-(defun citar-org-update-pre-suffix ()
-  "Change the pre/suffix text of the reference at point."
-  ;; TODO I want this to also work for global affixes on the citation,
-  ;;      but haven't figured that out yet.
-  (interactive)
+(defun citar-org--update-pre-suffix ()
+  "Change the prefix and suffix text of the reference at point."
   (let* ((datum (org-element-context))
          (datum-type (org-element-type datum))
          (ref (if (eq datum-type 'citation-reference) datum
@@ -461,6 +458,26 @@ or citation-reference."
                               (org-element-interpret-data
                                `(citation-reference
                                  (:key ,key :prefix ,pre :suffix ,post))))))
+
+(defun citar-org-update-pre-suffix (&optional arg)
+  "Change the prefix and suffix text of the reference at point.
+If given ARG, change the prefix and suffix for every reference in
+the citation at point."
+  (interactive "P")
+  (let* ((datum (org-element-context))
+         (citation-p (eq 'citation (org-element-type datum)))
+         (current-citation (if citation-p datum (org-element-property :parent datum)))
+         (refs (org-cite-get-references current-citation)))
+    (save-excursion
+      (if (or arg citation-p)
+          (dotimes (ref-index (length refs))
+            (goto-char (org-element-property :begin (nth ref-index refs)))
+            (citar-org--update-pre-suffix)
+            ;; Update refs since the begins and ends for the following reference could have changed when
+            ;; adding a prefix and/or suffix
+            (setq refs (org-cite-get-references
+                        (org-element-property :parent (org-element-context)))))
+        (citar-org--update-pre-suffix)))))
 
 ;; Load this last.
 


### PR DESCRIPTION
To resolve #607 and #606. The following pull request does the following:
1. Renames `citar-org-update-pre-suffix` to `citar-org-update-prefix-suffix`. I found the initial naming potentially misleading. This rename may increase the discoverability of the command.
2. Adds a helper function, `citar-org--update-prefix-suffix`.
3. (Unchanged) When on a reference, will prompt for a new prefix and suffix, with default values being their current values.
4. (New) When on a citation (but not a reference), will prompt for a new prefix and suffix **for every reference in the citation at point** from left to right.
5. (New) When on a reference and called with prefix arg, does the same as (4).
6. (New) There will always be *only one space* between citekey and citation suffix, unless there is no non-whitespace character in the suffix, in which case the suffix will be empty.

This new functionality uses purely the org-element API, meaning this should be a robust solution.

Additionally, I have manually tested the pull request through several edge cases, and have detected no bugs.

Finally, if this pull request goes through, I think it would be a good idea to (i) have `citar-org-update-prefix-suffix` be run after inserting a citation and (ii) have a customizable option to have toggle this behavior, potentially having it enabled by default.