### PR TITLE
Fix edge case for `citar-org-shift-reference-{left,right}`

### DIFF
--- a/citar-org.el
+++ b/citar-org.el
@@ -396,6 +396,8 @@ or citation-reference."
   (let*  ((current-citation (if (eq 'citation (org-element-type datum)) datum
                               (org-element-property :parent datum)))
           (current-ref (when (eq 'citation-reference (org-element-type datum)) datum))
+          (point-offset
+           (- (point) (org-element-property :begin current-ref)))
           (refs (org-cite-get-references current-citation))
           (index
            (citar-org--get-ref-index refs current-ref)))
@@ -421,8 +423,9 @@ or citation-reference."
                                 (org-element-interpret-data
                                  (citar-org-cite-swap index new-index refs)))
       ;; Now move point to the original ref.
-      (goto-char (org-element-property :begin (nth new-index
-                                                   (org-cite-get-references current-citation)))))))
+      (goto-char (+ (org-element-property :begin (nth new-index
+                                                      (org-cite-get-references current-citation)))
+                    point-offset)))))
 
 (defun citar-org-shift-reference-left ()
   "When point is on a citation-reference, shift it left."

--- a/citar-org.el
+++ b/citar-org.el
@@ -414,19 +414,15 @@ or citation-reference."
         ((v1
           (org-element-property :contents-begin current-citation))
          (v2
-          (org-element-property :contents-end current-citation)))
+          (org-element-property :contents-end current-citation))
+         (new-index
+          (if (eq 'left direction) (- index 1) (+ index 1))))
       (cl--set-buffer-substring v1 v2
                                 (org-element-interpret-data
-                                 (org-element-interpret-data
-                                  (citar-org-cite-swap
-                                   index
-                                   (if (eq 'left direction) (- index 1) (+ index 1)) refs)))))
-    ;; Now get on the original ref.
-    (let* ((newrefs (org-cite-get-references current-citation))
-           (index
-            (citar-org--get-ref-index newrefs current-ref)))
-
-      (goto-char (org-element-property :begin (nth index newrefs))))))
+                                 (citar-org-cite-swap index new-index refs)))
+      ;; Now move point to the original ref.
+      (goto-char (org-element-property :begin (nth new-index
+                                                   (org-cite-get-references current-citation)))))))
 
 (defun citar-org-shift-reference-left ()
   "When point is on a citation-reference, shift it left."

--- a/citar-org.el
+++ b/citar-org.el
@@ -370,8 +370,8 @@ or citation-reference."
   "Return index of citation-reference REF within REFS."
   (seq-position refs ref
                 (lambda (r1 r2)
-                  (and (string= (org-element-property :key r1)
-                                (org-element-property :key r2))))))
+                  (and (equal (org-element-property :begin r1)
+                              (org-element-property :begin r2))))))
 
 (defun citar-org-delete-citation ()
   "Delete the citation or citation-reference at point."


### PR DESCRIPTION
The current behavior for `citar-org-shift-reference-left` and `citar-org-shift-reference-right` fails when, in the same citation, there are multiple references with the same citekey (regardless of prefix and suffix differences). The reason for this lies in `citar-org--get-ref-index` using citekeys to retrieve the index of a reference within a citation.

This pull request has that function use the point at the beginning of a reference instead. Doing so required a slight change to how `citar-org--shift-reference` leaves the point on the correct reference.

Finally, the final commit enhances how the point is left on the reference: rather than left at the beginning, the point retains its position relative to where the command was called in the reference. For instance, if the command was called on the fourth character of the reference, it will remain there.