### PR TITLE
Make citar-{bibliography,library-paths,notes-paths} safe local vars

### DIFF
--- a/README.org
+++ b/README.org
@@ -171,6 +171,17 @@ By default, this uses ~citar-open-entry-in-file~, which will open the relevant b
 The other included option is ~citar-open-entry-in-zotero~, which will select the item in Zotero.
 Note that functionality depends on [[https://retorque.re/zotero-better-bibtex/][Better BibTeX]] (which you should be using anyway!).
 
+*** Per-project customization
+
+When collaborating with others, it might be convenient to have a project-specific bibliography file that can be version controlled and shared among collaborators.
+You can set ~citar-bibliography~ with =add-file-local-variable= or =add-dir-local-variable= to add a custom value to ~citar-bibliography~ for just that file or directory respectively.
+
+For example, if you are sharing a =custom_refs.bib= file adjacent to the =cool_new_paper.tex= that you're working on, using the aforementioned functions or adding the following to your =.dir-locals.el= will make citar /only/ search your shared bibliography:
+
+#+begin_src emacs-lisp
+((latex-mode . ((citar-bibliography . '("custom_refs.bib")))))
+#+end_src
+
 ** Rich UI
 :PROPERTIES:
 :CUSTOM_ID: rich-ui

--- a/README.org
+++ b/README.org
@@ -174,13 +174,10 @@ Note that functionality depends on [[https://retorque.re/zotero-better-bibtex/][
 *** Per-project customization
 
 When collaborating with others, it might be convenient to have a project-specific bibliography file that can be version controlled and shared among collaborators.
-You can set ~citar-bibliography~ with =add-file-local-variable= or =add-dir-local-variable= to add a custom value to ~citar-bibliography~ for just that file or directory respectively.
-
-For example, if you are sharing a =custom_refs.bib= file adjacent to the =cool_new_paper.tex= that you're working on, using the aforementioned functions or adding the following to your =.dir-locals.el= will make citar /only/ search your shared bibliography:
-
-#+begin_src emacs-lisp
-((latex-mode . ((citar-bibliography . '("custom_refs.bib")))))
-#+end_src
+Citar automatically uses bibliographies specified with ~\bibliography~ or ~\addbibresource~ in LaTeX and the ~#+bibliography~ keyword in org-mode.
+However, Citar will only use these if ~citar-bibliography~ is not set.
+Thus, if you have a global bibliography you've set in your ~init.el~ file, you can unset ~citar-bibliography~ on a per-project basis by setting it to ~nil~ as a file-local or a directory-local variable.
+For example, to set it to ~nil~ in your file-local variables, do ~M-x add-file-local-variable RET citar-bibliography RET nil RET~.
 
 ** Rich UI
 :PROPERTIES:

--- a/citar.el
+++ b/citar.el
@@ -81,13 +81,12 @@ buffer.")
 
 ;;;; Bibliography, file, and note paths
 
-;;;###autoload (put 'citar-bibliography 'safe-local-variable (lambda (val) (cl-every #'stringp val)))
+;;;###autoload (put 'citar-bibliography 'safe-local-variable (lambda (val) (eq val nil)))
 (defcustom citar-bibliography nil
   "A list of bibliography files."
   :group 'citar
   :type '(repeat file))
 
-;;;###autoload (put 'citar-library-paths 'safe-local-variable (lambda (val) (cl-every #'stringp val)))
 (defcustom citar-library-paths nil
   "A list of files paths for related PDFs, etc."
   :group 'citar
@@ -103,7 +102,6 @@ When nil, the function will not filter the list of files."
   :group 'citar
   :type '(repeat string))
 
-;;;###autoload (put 'citar-notes-paths 'safe-local-variable (lambda (val) (cl-every #'stringp val)))
 (defcustom citar-notes-paths nil
   "A list of file paths for bibliographic notes."
   :group 'citar

--- a/citar.el
+++ b/citar.el
@@ -81,11 +81,13 @@ buffer.")
 
 ;;;; Bibliography, file, and note paths
 
+;;;###autoload (put 'citar-bibliography 'safe-local-variable (lambda (val) (cl-every #'stringp val)))
 (defcustom citar-bibliography nil
   "A list of bibliography files."
   :group 'citar
   :type '(repeat file))
 
+;;;###autoload (put 'citar-library-paths 'safe-local-variable (lambda (val) (cl-every #'stringp val)))
 (defcustom citar-library-paths nil
   "A list of files paths for related PDFs, etc."
   :group 'citar
@@ -101,6 +103,7 @@ When nil, the function will not filter the list of files."
   :group 'citar
   :type '(repeat string))
 
+;;;###autoload (put 'citar-notes-paths 'safe-local-variable (lambda (val) (cl-every #'stringp val)))
 (defcustom citar-notes-paths nil
   "A list of file paths for bibliographic notes."
   :group 'citar


### PR DESCRIPTION
It is incredibly handy to customize `citar-bibliography` as a directory-local variable on a per-project basis. This worked so fabulously with the paper I just finished that I can't see myself not using this workflow again. I think a lot of people would like to use Citar in this way too.

I've added autoload cookies to put the safe local variable predicate on the symbol; the predicate is simply a list of strings. I followed how Denote by Prot was setting the safe local variable predicate on some denote variables.