### PR TITLE
Fix bug in `citar-citeproc-select-csl-style`

### DIFF
--- a/citar-citeproc.el
+++ b/citar-citeproc.el
@@ -83,7 +83,7 @@ accepted.")
                 files))
          (style
           (if (= (length list) 1)
-            (car list)
+              (caar list)
             (completing-read "Select CSL style file: " list nil t)))
          (file (cdr (assoc style list))))
     (setq citar-citeproc-csl-style file)))

--- a/citar-citeproc.el
+++ b/citar-citeproc.el
@@ -84,7 +84,7 @@ accepted.")
          (style
           (if (= (length list) 1)
               (caar list)
-            (completing-read "Select CSL style file: " list nil t)))
+            (completing-read "Select CSL style: " list nil t)))
          (file (cdr (assoc style list))))
     (setq citar-citeproc-csl-style file)))
 


### PR DESCRIPTION
Since `list` is a list of cons cells, to get the name of the csl style when `list` has one element `caar` needs to be used; `car` returns the cons cell itself.