### PR TITLE
citar-map: add `citar-add-file-to-library' to "a"

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -583,6 +583,7 @@ When nil, all citar commands will use `completing-read'."
 
 (defvar citar-map
   (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "a") #'citar-add-file-to-library)
     (define-key map (kbd "c") #'citar-insert-citation)
     (define-key map (kbd "k") #'citar-insert-keys)
     (define-key map (kbd "r") #'citar-copy-reference)


### PR DESCRIPTION
Hopefully, not *too* controversial a change but I find that I use this binding a lot, especially when cleaning up my references.