### PR TITLE
Local value predicates for bib data variables

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -84,11 +84,13 @@ buffer.")
 (defcustom citar-bibliography nil
   "A list of bibliography files."
   :group 'citar
+  :safe (lambda (val) (seq-every-p #'stringp val))
   :type '(repeat file))
 
 (defcustom citar-library-paths nil
   "A list of files paths for related PDFs, etc."
   :group 'citar
+  :safe (lambda (val) (seq-every-p #'stringp val))
   :type '(repeat directory))
 
 (defcustom citar-library-file-extensions nil
@@ -104,6 +106,7 @@ When nil, the function will not filter the list of files."
 (defcustom citar-notes-paths nil
   "A list of file paths for bibliographic notes."
   :group 'citar
+  :safe (lambda (val) (seq-every-p #'stringp val))
   :type '(repeat directory))
 
 (defcustom citar-crossref-variable "crossref"


### PR DESCRIPTION
I've started using a .bib file to hold data for my CV. When I'm working on the TeX in the CV folder, I the only bib data I want is that in my cv.bib.  I never really want to acces it otherwise. So it's useful if these variables can be set locally (using .dir-locals). To avoid having to confirm that they're safe every time, I've added a sensible test for safety.