### PR TITLE
feat: Add option to preserve TeX markup in cache

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -132,6 +132,15 @@ specifies additional fields to include."
   :group 'citar
   :type '(repeat string))
 
+(defcustom citar-cache-preserve-markup nil
+  "When non-nil, preserve TeX markup in bibliography fields.
+
+This can be useful for preserving capitalization in titles, for
+example, but it may have a performance impact when caching large
+bibliographies."
+  :group 'citar
+  :type 'boolean)
+
 ;;;; Displaying completions and formatting
 
 (defcustom citar-templates


### PR DESCRIPTION
This pull request attempts to address the problem reported in #784. **NB: the PR is not ready to be merged.** Please read below for a description of the required upstream changes.

The PR introduces a new user option, `citar-cache-preserve-markup`, to control whether TeX markup is preserved in bibliography fields when populating the Citar cache. This helps address issues with incorrect capitalization in formatted references, particularly when using `citeproc-el`.

#### Problem

When using `citar-insert-reference` with `citeproc-el`, titles and other fields may not be capitalized correctly. This is because `citar`'s caching mechanism, which uses `parsebib-parse`, strips TeX markup by default. For example, a title like `{Can humans be the {FORTRAN} of creatures?}` becomes `"Can humans be the fortran of creatures?"`, losing the intended capitalization of "FORTRAN".

#### Solution

This change introduces a new boolean custom variable, `citar-cache-preserve-markup`.

-   When `nil` (the default), `citar` maintains the existing behavior of stripping TeX markup.
-   When `t`, `citar` preserves TeX markup by passing `:display nil` to `parsebib-parse`.

The cache invalidation logic has also been updated. The cache will now be rebuilt if the value of `citar-cache-preserve-markup` changes, ensuring that the cached entries reflect the user's current setting.

#### Known Issues

Preserving markup across all fields can have side effects on downstream processors like `citeproc-el`, which may not expect markup in certain fields (e.g., `date` or `author`). This can lead to parsing errors or incorrect formatting for those fields.

This change provides a way to solve the capitalization issue, but a full solution requires improvements to the parsers in `citeproc-el`. Since I don’t understand the inner workings of this other package, I am not able to implement those changes myself.