### PR TITLE
fix: prevent stale cache after failed bibliography parse

### DIFF
--- a/citar-cache.el
+++ b/citar-cache.el
@@ -230,17 +230,12 @@ its return value can be reused.
 After updating, the `props' slot of BIB is set to PROPS."
   (let* ((filename (citar-cache--bibliography-filename bib))
          (props (or props (citar-cache--get-bibliography-props filename)))
-         (entries (citar-cache--bibliography-entries bib))
          (messagestr (format "Updating bibliography %s" (abbreviate-file-name filename)))
          (starttime (current-time)))
     (message "%s..." messagestr)
     (redisplay)                         ; Make sure message is displayed before Emacs gets busy parsing
-    ;; Parse into a temp table so a failed parse does not leave
-    ;; the cache in a partially-updated state.
-    (let ((new-entries (parsebib-parse filename)))
-      (clrhash entries)
-      (maphash (lambda (k v) (puthash k v entries)) new-entries))
-    (setf (citar-cache--bibliography-props bib) props)
+    (setf (citar-cache--bibliography-entries bib) (parsebib-parse filename)
+          (citar-cache--bibliography-props bib) props)
     (citar-cache--preformat-bibliography bib)
     (message "%s...done (%.3f seconds)" messagestr (float-time (time-since starttime)))))
 

--- a/citar-cache.el
+++ b/citar-cache.el
@@ -235,8 +235,11 @@ After updating, the `props' slot of BIB is set to PROPS."
          (starttime (current-time)))
     (message "%s..." messagestr)
     (redisplay)                         ; Make sure message is displayed before Emacs gets busy parsing
-    (clrhash entries)
-    (parsebib-parse filename :entries entries)
+    ;; Parse into a temp table so a failed parse does not leave
+    ;; the cache in a partially-updated state.
+    (let ((new-entries (parsebib-parse filename)))
+      (clrhash entries)
+      (maphash (lambda (k v) (puthash k v entries)) new-entries))
     (setf (citar-cache--bibliography-props bib) props)
     (citar-cache--preformat-bibliography bib)
     (message "%s...done (%.3f seconds)" messagestr (float-time (time-since starttime)))))


### PR DESCRIPTION
When citar-cache--update-bibliography re-parses a bibliography, it previously called (clrhash entries) before (parsebib-parse), destroying the existing valid entries. If parsebib-parse then errored partway through (e.g., because an external tool like Zotero Better BibTeX was mid-write when citar read the file), the entries hash table was left partially filled. Since the bib object was already in the cache from a prior successful run, the corrupted state persisted. And because props were never updated (the line after the failed parse), subsequent cache checks saw "no changes needed", so the stale partial entries were never refreshed—even after the bib file was fully written.

Fix by parsing into a temporary hash table first, and only replacing the cached entries on success. If parsebib-parse errors, the cache retains its previous valid entries.