### PR TITLE
fix: prevent partial preformatted cache after interrupted update

### DIFF
--- a/citar-cache.el
+++ b/citar-cache.el
@@ -245,8 +245,8 @@ After updating, the `props' slot of BIB is set to PROPS."
   (let* ((entries (citar-cache--bibliography-entries bib))
          (formatstr (citar-cache--bibliography-format-string bib))
          (fieldspecs (citar-format--parse formatstr))
-         (preformatted (citar-cache--bibliography-preformatted bib)))
-    (clrhash preformatted)
+         (preformatted (make-hash-table :test 'equal
+                                        :size (hash-table-count entries))))
     (maphash
      (lambda (citekey entry)
        (let* ((preformat (citar-format--preformat fieldspecs entry
@@ -254,7 +254,8 @@ After updating, the `props' slot of BIB is set to PROPS."
               (withkey (citar--prepend-candidate-citekey citekey (cadr preformat))))
          (setcdr preformat (cons withkey (cddr preformat)))
          (puthash citekey preformat preformatted)))
-     entries)))
+     entries)
+    (setf (citar-cache--bibliography-preformatted bib) preformatted)))
 
 
 ;;; Utility functions:


### PR DESCRIPTION
## Summary

`citar-cache--preformat-bibliography` previously updated the bib's preformatted hash in place via `clrhash` followed by `maphash` + `puthash`. If the refill is interrupted partway through — for example, `C-g` during an idle-time update of a large bibliography — the preformatted hash is left with only a fraction of the entries. Because `citar-cache--update-bibliography` has already set `props` before calling the preformatter, subsequent cache-up-to-date checks see "no changes needed" and the partial preformatted cache persists indefinitely. `citar--format-candidates` then errors with

```
No preformatted candidate string: <KEY>
```

on any entry that didn't make it into the hash before the interruption, breaking `citar-insert-citation`, `citar-select-refs`, etc.

I hit this against a ~15k-entry bibliography: after some earlier interruption, the bib's entries cache had 14,662 keys but the preformatted cache only had 7,986. The partial state then persisted across Emacs sessions until `citar-cache--preformat-bibliography` was called manually.

## Fix

Build the new preformatted hash in a fresh local hash table and replace the bib slot via `setf` only after `maphash` completes. If the maphash is interrupted, the `setf` never runs and the existing (valid) preformatted hash is retained.

This mirrors the atomicity pattern introduced in #882 for the entries slot.

## Test plan

- [x] Exercised the patched function against the affected bibliography; `preformatted` is fully populated (14,662/14,662) and the previously missing key resolves.
- [x] Verified the hash is a fresh object (`eq` returns nil against the old slot value), confirming the atomic swap.
- [x] Byte-compiles cleanly.