### PR TITLE
feat: Customizable basename for citar-export-local-bib-file

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -1762,6 +1762,13 @@ buffer's directory in typical usage)."
       (dolist (citekey citekeys)
         (citar--insert-bibtex citekey)))))
 
+(define-obsolete-function-alias
+  'citar-export-local-bib-file
+  'citar-export-local-bibtex-file
+  "1.5"
+  "Renamed for clarity: the function writes BibTeX, not a generic
+\"bib file\".")
+
 ;;;###autoload
 (defun citar-insert-citation (citekeys &optional arg)
   "Insert citation for the CITEKEYS.

--- a/citar.el
+++ b/citar.el
@@ -350,6 +350,24 @@ always prompt to select."
   :group 'citar
   :type '(repeat string))
 
+(defcustom citar-export-local-bibtex-base-name "local-bib"
+  "Basename (without extension) for `citar-export-local-bibtex-file'.
+
+The value may be:
+
+  - a string — used as the literal basename;
+  - a function — called with no arguments, expected to return a
+    basename string;
+  - nil — defer to `citar-local-bibtex-base-name'.
+
+The file extension is taken from the first entry of
+`citar-bibliography'."
+  :type '(choice
+          (const    :tag "Mode-aware default (`citar-local-bibtex-base-name')" nil)
+          (string   :tag "Literal basename")
+          (function :tag "Function returning basename"))
+  :group 'citar)
+
 ;;;; File, note, and URL handling
 
 (defcustom citar-open-resources '(:files :links :notes :create-notes)

--- a/citar.el
+++ b/citar.el
@@ -1734,16 +1734,30 @@ user option."
       "references"))
 
 ;;;###autoload
-(defun citar-export-local-bib-file ()
-  "Create a new bibliography file from citations in current buffer.
+(defun citar-export-local-bibtex-file (filename)
+  "Create a new BibTeX file FILENAME from citations in the current buffer.
 
-The file is titled \"local-bib\", given the same extension as
-the first entry in `citar-bibliography', and created in the same
-directory as current buffer."
-  (interactive)
+When called interactively without a prefix argument, FILENAME is
+derived from `citar-export-local-bibtex-base-name'; with a prefix
+argument, prompt for FILENAME.
+
+The file extension is taken from the first entry of
+`citar-bibliography'; if FILENAME already carries an extension, it is
+replaced.  The file is created in `default-directory' (the current
+buffer's directory in typical usage)."
+  (interactive
+   (list
+    (cond
+      (current-prefix-arg
+       (read-file-name "File name: "))
+      ((functionp citar-export-local-bibtex-base-name)
+       (funcall citar-export-local-bibtex-base-name))
+      ((stringp citar-export-local-bibtex-base-name)
+       citar-export-local-bibtex-base-name)
+      (t (citar-local-bibtex-base-name)))))
   (let* ((citekeys (citar--major-mode-function 'list-keys #'ignore))
          (ext (file-name-extension (car citar-bibliography)))
-         (file (format "%slocal-bib.%s" (file-name-directory buffer-file-name) ext)))
+         (file (expand-file-name (file-name-with-extension filename ext))))
     (with-temp-file file
       (dolist (citekey citekeys)
         (citar--insert-bibtex citekey)))))

--- a/citar.el
+++ b/citar.el
@@ -1721,6 +1721,18 @@ including the citekeys, is maintained in Zotero with Better BibTeX."
     (unless (equal entry "")
       (insert entry "\n\n"))))
 
+(defun citar-local-bibtex-base-name ()
+  "Derive bibtex basename from buffer's local bibliography file.
+Tries to extract the basename (no directory or extension) from the
+current buffer's bibliography file declaration, falling back to
+\"references\".
+
+Intended for use as a value of the `citar-export-local-bibtex-base-name'
+user option."
+  (or (when-let ((bibs (citar--local-bibliography-files)))
+        (file-name-base (car bibs)))
+      "references"))
+
 ;;;###autoload
 (defun citar-export-local-bib-file ()
   "Create a new bibliography file from citations in current buffer.

--- a/citar.el
+++ b/citar.el
@@ -641,6 +641,18 @@ When nil, all citar commands will use `completing-read'."
 
 ;;; Bibliography cache
 
+(defun citar--local-bibliography-files (&optional buffer)
+  "Return a list of local bibliography files for BUFFER.
+BUFFER defaults to the current buffer. Local bibliography files are
+those declared by per-mode mechanisms (e.g. Org `#+bibliography:', TeX
+`\\bibliography{}' / `\\addbibresource{}'), excluding the global
+`citar-bibliography'.
+
+Files that do not exist are not filtered or validated; callers can do
+so as needed."
+  (with-current-buffer (or buffer (current-buffer))
+    (citar--major-mode-function 'local-bib-files #'ignore)))
+
 (defun citar--bibliography-files (&rest buffers)
   "Bibliography file names for BUFFERS.
 The elements of BUFFERS are either buffers or the symbol global.
@@ -652,10 +664,8 @@ buffer and global bibliographies."
   (citar-file--normalize-paths
    (mapcan (lambda (buffer)
              (if (eq buffer 'global)
-                 (if (listp citar-bibliography) citar-bibliography
-                   (list citar-bibliography))
-               (with-current-buffer buffer
-                 (citar--major-mode-function 'local-bib-files #'ignore))))
+                 (ensure-list citar-bibliography)
+               (citar--local-bibliography-files)))
            (or buffers (list (current-buffer) 'global)))))
 
 (defun citar--bibliographies (&rest buffers)

--- a/test/citar-test.el
+++ b/test/citar-test.el
@@ -12,5 +12,68 @@
   ;; This should run without signalling an error
   (should-not (ignore (map-do #'citar--check-notes-source citar-notes-sources))))
 
+(ert-deftest citar-test--local-bibtex-base-name-fallback ()
+  "Returns \"references\" when buffer has no local bibliography."
+  (let ((citar-major-mode-functions `((t . ((local-bib-files . ignore))))))
+    (should (string= "references" (citar-local-bibtex-base-name)))))
+
+(ert-deftest citar-test--local-bibtex-base-name-from-local ()
+  "Returns the basename of the first local bibliography file."
+  (let ((citar-major-mode-functions
+         `((t . ((local-bib-files
+                  . ,(lambda (&rest _) '("/tmp/projectA.bib"
+                                         "/tmp/projectB.bib"))))))))
+    (should (string= "projectA" (citar-local-bibtex-base-name)))))
+
+(ert-deftest citar-test--export-local-bibtex-file-writes-citations ()
+  "Writes cited entries to FILENAME."
+  (let* ((source (make-temp-file "citar-test-src" nil ".bib"))
+         (target (file-name-with-extension
+                  (make-temp-name
+                   (concat temporary-file-directory "citar-test-tgt"))
+                  "bib"))
+         (entry-foo "@article{foo2026,\n title = {Foo},\n author = {Alice}\n}\n")
+         (entry-bar "@article{bar2026,\n title = {Bar},\n author = {Bob}\n}\n"))
+    (unwind-protect
+         (progn
+           (with-temp-file source
+             (insert entry-foo entry-bar))
+           (let ((citar-bibliography (list source))
+                 (citar-major-mode-functions
+                  `((t . ((list-keys . ,(lambda () '("foo2026")))
+                          (local-bib-files . ignore))))))
+             (citar-export-local-bibtex-file target))
+           (should (file-exists-p target))
+           (with-temp-buffer
+             (insert-file-contents target)
+             (should (string-match entry-foo (buffer-string)))))
+      (delete-file source)
+      (delete-file target))))
+
+(ert-deftest citar-test--export-local-bibtex-base-name-string-used ()
+  "When `citar-export-local-bibtex-base-name' is a string, exported file is named after it."
+  (let* ((default-directory temporary-file-directory)
+         (source (make-temp-file "citar-test-src" nil ".bib"))
+         (host (expand-file-name "project.org"))
+         (basename "local-bib")
+         (expected (expand-file-name (concat basename ".bib")))
+         (entry "@article{foo2026,\n title = {Foo}\n}\n"))
+    (unwind-protect
+         (progn
+           (with-temp-file source (insert entry))
+           (with-current-buffer (find-file-literally host)
+             (let ((current-prefix-arg nil)
+                   (citar-export-local-bibtex-base-name basename)
+                   (citar-bibliography (list source))
+                   (citar-major-mode-functions
+                    `((t . ((list-keys . ,(lambda () '("foo2026")))
+                            (local-bib-files . ignore)))))
+                   (kill-buffer-query-functions nil))
+               (call-interactively #'citar-export-local-bibtex-file))
+             (kill-buffer))
+           (should (file-exists-p expected)))
+      (delete-file source)
+      (delete-file expected))))
+
 (provide 'citar-test)
 ;;; citar-test.el ends here


### PR DESCRIPTION
## Summary

Makes `citar-export-local-bibtex-file` (renamed from `citar-export-local-bib-file`) flexible:

- Takes a `FILENAME` argument; with prefix arg, prompts the user.
- Without prefix arg, derives the basename from a new user option `citar-export-local-bibtex-base-name` — string, function, or `nil` for a mode-aware default.
- The `nil` choice falls back to a new helper `citar-local-bibtex-base-name`, which derives a basename from the buffer's bibliography declaration (Org `#+bibliography:`, TeX `\bibliography{}`) via the new private `citar--local-bibliography-files`.

## Motivation

The hardcoded `local-bib.<ext>` output is opaque and conflicts with workflows where a project's bibliography file has a meaningful name (e.g., `references.bib`). Letting users choose the basename, or derive it from the buffer's own bibliography declaration, gives users much more flexibility when generating a local BibTeX file from citations.

The rename clarifies that the function writes BibTeX, not a generic "bib" artifact.

## Backwards compatibility

- Default value of the user option (`"local-bib"`) preserves prior behavior.
- Old function name retained via `define-obsolete-function-alias`.

## Public API additions

- `citar-export-local-bibtex-base-name` (defcustom)
- `citar-local-bibtex-base-name` (helper)
- `citar-export-local-bibtex-file` (renamed function)