### PR TITLE
refactor: Skip missing per-buffer local bibliography files

### DIFF
--- a/citar-file.el
+++ b/citar-file.el
@@ -84,23 +84,6 @@ separator that does not otherwise occur in citation keys."
 (defvar citar-library-file-extensions)
 (defvar citar-note-format-function)
 
-;;;; Convenience functions for files and paths
-
-(defun citar-file--normalize-paths (file-paths)
-  "Return a list of FILE-PATHS normalized with truename."
-  ;; REVIEW why hassle with this; just require a list?
-  (let ((paths (if (stringp file-paths)
-                   (list file-paths)
-                 file-paths)))
-  (citar-file--files-exist-p paths)
-  (delete-dups (mapcar #'file-truename paths))))
-
-(defun citar-file--files-exist-p (files)
-  "Check each of a list of FILES exists."
-  (dolist (file files)
-     (unless (file-exists-p file)
-       (user-error "Cannot find file: %s" file))))
-
 ;;;; Parsing file fields
 
 (defun citar-file--parser-default (file-field)

--- a/citar.el
+++ b/citar.el
@@ -623,6 +623,29 @@ When nil, all citar commands will use `completing-read'."
 
 ;;; Bibliography cache
 
+(defun citar--global-bibliography-files ()
+  "Return `citar-bibliography', validated.
+Signal a `user-error' if `citar-bibliography' is not a list, or if any
+of its entries does not name an existing file."
+  (unless (listp citar-bibliography)
+    (user-error "`citar-bibliography' must be a list"))
+  (dolist (file citar-bibliography)
+    (unless (file-exists-p file)
+      (user-error "Cannot find file: %s" file)))
+  citar-bibliography)
+
+(defun citar--local-bibliography-files (&optional buffer)
+  "Return a list of local bibliography files for BUFFER.
+BUFFER defaults to the current buffer. Local bibliography files are
+those declared by per-mode mechanisms (e.g. Org `#+bibliography:', TeX
+`\\bibliography{}' / `\\addbibresource{}'), excluding the global
+`citar-bibliography'.
+
+Files that do not exist are not filtered or validated; callers can do
+so as needed."
+  (with-current-buffer (or buffer (current-buffer))
+    (citar--major-mode-function 'local-bib-files #'ignore)))
+
 (defun citar--bibliography-files (&rest buffers)
   "Bibliography file names for BUFFERS.
 The elements of BUFFERS are either buffers or the symbol global.

--- a/citar.el
+++ b/citar.el
@@ -654,14 +654,14 @@ these contexts.
 
 When BUFFERS is nil, return local bibliographies for the current
 buffer and global bibliographies."
-  (citar-file--normalize-paths
-   (mapcan (lambda (buffer)
-             (if (eq buffer 'global)
-                 (if (listp citar-bibliography) citar-bibliography
-                   (list citar-bibliography))
-               (with-current-buffer buffer
-                 (citar--major-mode-function 'local-bib-files #'ignore))))
-           (or buffers (list (current-buffer) 'global)))))
+  (let* ((buffers (or buffers (list (current-buffer) 'global)))
+         (globals (when (memq 'global buffers)
+                    (citar--global-bibliography-files)))
+         (locals (seq-filter #'file-exists-p
+                             (mapcan #'citar--local-bibliography-files
+                                     (delq 'global buffers)))))
+    (delete-dups
+     (mapcar #'file-truename (append globals locals)))))
 
 (defun citar--bibliographies (&rest buffers)
   "Return bibliographies for BUFFERS."

--- a/test/citar-test.el
+++ b/test/citar-test.el
@@ -12,5 +12,51 @@
   ;; This should run without signalling an error
   (should-not (ignore (map-do #'citar--check-notes-source citar-notes-sources))))
 
+(ert-deftest citar-test--bibliography-files-global-only ()
+  "Existing global bibliography is returned."
+  (let ((tmp (make-temp-file "citar-test-global" nil ".bib")))
+    (unwind-protect
+         (let ((citar-bibliography (list tmp))
+               (citar-major-mode-functions
+                '((t . ((local-bib-files . ignore))))))
+           (should (member (file-truename tmp)
+                           (citar--bibliography-files))))
+      (delete-file tmp))))
+
+(ert-deftest citar-test--bibliography-files-missing-global-errors ()
+  "Missing global bibliography signals a `user-error'."
+  (let ((citar-bibliography '("/tmp/citar-test-nonexistent-glob.bib"))
+        (citar-major-mode-functions
+         '((t . ((local-bib-files . ignore))))))
+    (should-error (citar--bibliography-files) :type 'user-error)))
+
+(ert-deftest citar-test--bibliography-files-missing-local-filtered ()
+  "Missing local bibliography is silently filtered."
+  (let ((tmp (make-temp-file "citar-test-glob" nil ".bib"))
+        (missing "/tmp/citar-test-nonexistent-local.bib"))
+    (unwind-protect
+         (let* ((citar-bibliography (list tmp))
+                (citar-major-mode-functions
+                 `((t . ((local-bib-files . ,(lambda () (list missing)))))))
+                (result (citar--bibliography-files)))
+           (should (member (file-truename tmp) result))
+           (should-not (member missing result))
+           (should-not (member (file-truename missing) result)))
+      (delete-file tmp))))
+
+(ert-deftest citar-test--bibliography-files-existing-local-included ()
+  "Existing local bibliography is included."
+  (let ((tmp-glob (make-temp-file "citar-test-glob" nil ".bib"))
+        (tmp-local (make-temp-file "citar-test-local" nil ".bib")))
+    (unwind-protect
+         (let* ((citar-bibliography (list tmp-glob))
+                (citar-major-mode-functions
+                 `((t . ((local-bib-files . ,(lambda () (list tmp-local)))))))
+                (result (citar--bibliography-files)))
+           (should (member (file-truename tmp-glob) result))
+           (should (member (file-truename tmp-local) result)))
+      (delete-file tmp-glob)
+      (delete-file tmp-local))))
+
 (provide 'citar-test)
 ;;; citar-test.el ends here


### PR DESCRIPTION
## Summary

`citar--bibliography-files` now treats missing per-buffer local bibliography files as a soft case (silently filtered) instead of an error. Globals (`citar-bibliography`) retain the previous strict existence check.

## Motivation

The pre-flight existence check (introduced in #765) conflates two cases:

- **Global config**: paths in `citar-bibliography` are user-configured up front. A missing global typically indicates a typo and should fail fast.
- **Per-buffer locals**: paths declared via mechanisms like Org `#+bibliography:` or TeX `\bibliography{}`. These may legitimately point to files that haven't been written yet — e.g. a project-local bib materialized after writing citations via `citar-export-local-bibtex-file`.

Treating both equally meant inserting a citation into an Org buffer with `#+bibliography: project.bib` errored out before `project.bib` existed, blocking the natural pre-export workflow.

## Changes

- New helpers `citar--global-bibliography-files` (validates) and `citar--local-bibliography-files` (does not validate).
- Rewrite `citar--bibliography-files` to use them.
- Remove `citar-file--normalize-paths` and `citar-file--files-exist-p` (no longer used).
- Tests for the four cases (global only, missing global errors, missing local filtered, both included).

## Backwards compatibility

- Globals still validated — config typos still caught.
- Locals previously errored on missing; now silently filtered.