### PR TITLE
fix: break on configs that separate `C-i` from `TAB`

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -752,7 +752,13 @@ is used for exiting the minibuffer during completing read.")
 (defun citar--multiple-exit ()
   "Exit with the currently selected candidates."
   (interactive)
-  (setq unread-command-events (listify-key-sequence (kbd (car citar--multiple-setup)))))
+  (setq unread-command-events
+        (mapcar (lambda (event)
+                  (alist-get event '((?\t . tab)
+                                     (?\r . return)
+                                     (?\e . escape))
+                             event))
+                (listify-key-sequence (kbd (car citar--multiple-setup))))))
 
 (defun citar--setup-multiple-keymap ()
   "Make a keymap suitable for `citar--select-multiple'."


### PR DESCRIPTION
Relate to #802 and [hel#31](https://github.com/helheim-emacs/hel/issues/31)

There is a common trick to distinguish `C-i` from `Tab` on GUI Emacs via `input-decode-map`. This is possible, because Emacs GUI reports physical Tab key as the symbol `tab` and `Ctrl+i` as the character 9. The same for Enter and Esc.

Currently, `citar--multiple-exit` replays the selection key by pushing the raw character `?\t` into `unread-command-events` which is then decoded as `C-i`, which nothing binds:

```
  1. RET on a candidate
       ▼
  2. citar--setup-multiple-keymap bound RET -> citar--multiple-exit
       ▼
  3. (setq unread-command-events (listify-key-sequence (kbd "TAB")))
     ...(kbd "TAB") is the single character 9, not the symbol `tab'
       ▼
  4. Emacs re-reads 9 -> input-decode-map -> [C-i]
       ▼
  5. citar's composed keymap binds TAB; nothing binds C-i
       ▼
  6. "<C-i> is undefined"
```

This patch replaces char `9` with symbol `tab` in `unread-command-events`. On GUI frames, it will be handled correctly and avoid the collision. On TTY, it will be translated back to 9 anyway.
